### PR TITLE
refactor: convert temp auth page into angular component

### DIFF
--- a/src/app/features/dashboard/components/temp-auth/temp-auth.component.html
+++ b/src/app/features/dashboard/components/temp-auth/temp-auth.component.html
@@ -1,121 +1,145 @@
 <div class="temp-auth-page">
-  <div class="page-header">
+  <header class="page-header">
     <h1>
-      🔐 کلاینت آزمایشی WebAuthn
-      <span>امکان تست تمامی سرویس‌های /api/webauthn/* در محیط مرورگر</span>
+      صفحه موقت احراز هویت
+      <span>شبیه‌سازی فرآیند ثبت‌نام، ورود و WebAuthn در محیط آزمایشی</span>
     </h1>
     <p>
-      از این صفحه برای ثبت، احراز هویت و مدیریت دستگاه‌های WebAuthn استفاده کنید. پیکربندی درخواست‌ها را مطابق با محیط
-      اجرایی خود تنظیم نموده و سپس عملیات مورد نظر را آغاز کنید.
+      برای تجربه کامل، ابتدا یکی از فرم‌های زیر را تکمیل کنید. پس از دریافت توکن، وضعیت احراز هویت و مرحله بعدی از طریق
+      کارت «وضعیت احراز هویت» نمایش داده می‌شود.
     </p>
-  </div>
+  </header>
 
-  <div nz-row [nzGutter]="[16, 16]">
-    <div nz-col [nzSpan]="24" [nzLg]="14">
-      <nz-card nzTitle="پیکربندی درخواست" class="config-card">
-        <div class="config-grid">
+  <div nz-row [nzGutter]="[16, 16]" class="forms-row">
+    <div nz-col [nzSpan]="24" [nzLg]="12">
+      <nz-card nzTitle="ثبت‌نام کاربر جدید">
+        <form class="auth-form" (ngSubmit)="submitSignUp()">
           <label class="form-field">
-            <span class="label-text">آدرس پایه API</span>
-            <input nz-input type="url" [(ngModel)]="apiBase" placeholder="http://localhost:8001/api" />
+            <span class="label">نام کاربری</span>
+            <input nz-input name="signup-username" [(ngModel)]="signUpForm.username" required placeholder="user1" />
           </label>
-
-          <label class="form-field full-width">
-            <span class="label-text">هدر احراز هویت</span>
-            <textarea
-              nz-input
-              rows="3"
-              [(ngModel)]="authToken"
-              placeholder="Bearer &lt;jwt&gt;"
-            ></textarea>
+          <label class="form-field">
+            <span class="label">ایمیل</span>
+            <input nz-input type="email" name="signup-email" [(ngModel)]="signUpForm.email" required placeholder="user@example.com" />
           </label>
-        </div>
-
-        <div class="action-row">
-          <button nz-button nzType="primary" (click)="startRegistration()" [nzLoading]="loading.register">
-            شروع ثبت‌نام
+          <label class="form-field">
+            <span class="label">رمز عبور</span>
+            <input nz-input type="password" name="signup-password" [(ngModel)]="signUpForm.password" required placeholder="رمز عبور" />
+          </label>
+          <button nz-button nzType="primary" [nzLoading]="loading.signUp" type="submit">
+            ثبت‌نام
           </button>
-          <button nz-button nzType="default" (click)="startAuthentication()" [nzLoading]="loading.authenticate">
-            شروع احراز هویت
-          </button>
-          <button nz-button nzType="default" nzGhost (click)="listDevices()" [nzLoading]="loading.list">
-            به‌روزرسانی دستگاه‌ها
-          </button>
-          <button nz-button nzType="default" nzGhost (click)="getMe()" [nzLoading]="loading.getMe">
-            دریافت اطلاعات کاربر
-          </button>
-        </div>
+        </form>
       </nz-card>
     </div>
+    <div nz-col [nzSpan]="24" [nzLg]="12">
+      <nz-card nzTitle="ورود کاربر">
+        <form class="auth-form" (ngSubmit)="submitSignIn()">
+          <label class="form-field">
+            <span class="label">نام کاربری</span>
+            <input nz-input name="signin-username" [(ngModel)]="signInForm.username" required placeholder="user1" />
+          </label>
+          <label class="form-field">
+            <span class="label">رمز عبور</span>
+            <input nz-input type="password" name="signin-password" [(ngModel)]="signInForm.password" required placeholder="رمز عبور" />
+          </label>
+          <button nz-button nzType="primary" [nzLoading]="loading.signIn" type="submit">
+            ورود
+          </button>
+        </form>
+      </nz-card>
+    </div>
+  </div>
 
-    <div nz-col [nzSpan]="24" [nzLg]="10" class="side-column">
-      <nz-card nzTitle="حذف دستگاه" class="delete-card">
-        <p class="card-helper">شناسه Credential را از لیست دستگاه‌ها یا پاسخ سرویس دریافت کرده و در این قسمت وارد کنید.</p>
-        <div class="delete-grid">
+  <nz-card nzTitle="وضعیت احراز هویت" class="session-card">
+    <div class="session-header">
+      <div class="next-step">
+        <span class="label">گام بعدی:</span>
+        <strong>{{ nextStepDescription }}</strong>
+      </div>
+      <nz-tag *ngIf="state?.auth_stage" nzColor="blue">{{ state?.auth_stage }}</nz-tag>
+      <nz-tag *ngIf="fullyAuthenticated" nzColor="green">احراز هویت نهایی شد</nz-tag>
+    </div>
+
+    <div class="session-body">
+      <div class="session-info" *ngIf="session; else guestInfo">
+        <p><strong>کاربر:</strong> {{ session?.username }}</p>
+        <p><strong>ایمیل:</strong> {{ session?.email }}</p>
+        <p><strong>شناسه کاربر:</strong> {{ session?.id }}</p>
+        <p><strong>ایجاد شده در:</strong> {{ session?.created_at | date: 'medium' }}</p>
+      </div>
+      <ng-template #guestInfo>
+        <p>هنوز اطلاعات کاربری دریافت نشده است. ابتدا ثبت‌نام یا ورود را انجام دهید.</p>
+      </ng-template>
+    </div>
+
+    <div class="api-field">
+      <label>
+        <span>آدرس پایه API</span>
+        <input
+          nz-input
+          [(ngModel)]="apiBase"
+          [ngModelOptions]="{ standalone: true }"
+          placeholder="http://localhost:8001/api"
+        />
+      </label>
+    </div>
+
+    <div class="session-actions">
+      <button nz-button nzType="default" (click)="refreshSession()" [nzLoading]="loading.session">
+        به‌روزرسانی وضعیت
+      </button>
+
+      <ng-container *ngIf="requiresRegistration">
+        <div class="device-controls">
           <input
             nz-input
-            [(ngModel)]="credentialId"
-            placeholder="شناسه Credential"
-            aria-label="شناسه Credential"
+            placeholder="نام دستگاه (اختیاری)"
+            [(ngModel)]="deviceName"
+            [ngModelOptions]="{ standalone: true }"
           />
-          <button
-            nz-button
-            nzType="default"
-            nzDanger
-            (click)="deleteDevice()"
-            [nzLoading]="loading.delete"
-          >
-            حذف دستگاه
+          <button nz-button nzType="primary" (click)="registerDevice()" [nzLoading]="loading.register">
+            ثبت دستگاه
           </button>
         </div>
-      </nz-card>
+      </ng-container>
 
-      <nz-card nzTitle="دستگاه‌های ثبت‌شده" class="devices-card" [nzLoading]="loading.list">
-        <ng-container *ngIf="devices.length; else emptyDevices">
-          <div class="device-card" *ngFor="let device of devices">
-            <div class="device-header">
-              <h3>{{ device.device_name || 'بدون نام' }}</h3>
-              <nz-tag nzColor="blue">{{ device.sign_count }} بار استفاده</nz-tag>
-            </div>
-            <dl>
-              <div>
-                <dt>Credential ID</dt>
-                <dd>{{ device.credential_id }}</dd>
-              </div>
-              <div>
-                <dt>تاریخ ایجاد</dt>
-                <dd>{{ device.created_at || '—' }}</dd>
-              </div>
-              <div>
-                <dt>آخرین استفاده</dt>
-                <dd>{{ device.last_used || '—' }}</dd>
-              </div>
-            </dl>
-          </div>
-        </ng-container>
-        <ng-template #emptyDevices>
-          <p class="empty-state">تا کنون دستگاهی ثبت نشده است.</p>
-        </ng-template>
-      </nz-card>
+      <button
+        nz-button
+        nzType="primary"
+        nzGhost
+        *ngIf="requiresAuthentication"
+        (click)="authenticateDevice()"
+        [nzLoading]="loading.authenticate"
+      >
+        احراز هویت با دستگاه
+      </button>
+
+      <p class="success-message" *ngIf="fullyAuthenticated">
+        کاربر با موفقیت احراز هویت شد و نیازی به اقدام دیگری نیست.
+      </p>
     </div>
-  </div>
+  </nz-card>
 
-  <nz-card nzTitle="گزارش‌ها" class="log-card">
+  <nz-card nzTitle="گزارش رویدادها" class="log-card">
     <div class="log-toolbar">
-      <button nz-button nzType="default" nzGhost (click)="clearLog()">پاک‌سازی گزارش‌ها</button>
+      <button nz-button nzType="default" nzGhost (click)="clearLogs()">پاک‌سازی گزارش‌ها</button>
     </div>
     <div class="log-container" #logContainer>
-      <ng-container *ngIf="logs.length; else emptyLogs">
+      <ng-container *ngIf="logs.length; else emptyLog">
         <div class="log-entry" *ngFor="let entry of logs" [ngClass]="entry.level">
           <div class="log-entry__header">
             <span class="timestamp">{{ entry.timestamp }}</span>
-            <nz-tag [nzColor]="logColor(entry.level)">{{ entry.level | uppercase }}</nz-tag>
+            <nz-tag [nzColor]="entry.level === 'error' ? 'red' : entry.level === 'success' ? 'green' : 'blue'">
+              {{ entry.level | uppercase }}
+            </nz-tag>
           </div>
           <p class="message">{{ entry.message }}</p>
           <pre class="detail" *ngIf="entry.detail">{{ entry.detail }}</pre>
         </div>
       </ng-container>
-      <ng-template #emptyLogs>
-        <p class="empty-state">هنوز گزارشی ثبت نشده است.</p>
+      <ng-template #emptyLog>
+        <p class="empty-state">هنوز رویدادی ثبت نشده است.</p>
       </ng-template>
     </div>
   </nz-card>

--- a/src/app/features/dashboard/components/temp-auth/temp-auth.component.html
+++ b/src/app/features/dashboard/components/temp-auth/temp-auth.component.html
@@ -1,97 +1,69 @@
 <div class="temp-auth-page">
-  <header class="page-header">
-    <h1>
-      صفحه موقت احراز هویت
-      <span>شبیه‌سازی فرآیند ثبت‌نام، ورود و WebAuthn در محیط آزمایشی</span>
-    </h1>
-    <p>
-      برای تجربه کامل، ابتدا یکی از فرم‌های زیر را تکمیل کنید. پس از دریافت توکن، وضعیت احراز هویت و مرحله بعدی از طریق
-      کارت «وضعیت احراز هویت» نمایش داده می‌شود.
-    </p>
-  </header>
+  <p class="status-message">{{ statusMessage }}</p>
 
-  <div nz-row [nzGutter]="[16, 16]" class="forms-row">
-    <div nz-col [nzSpan]="24" [nzLg]="12">
-      <nz-card nzTitle="ثبت‌نام کاربر جدید">
-        <form class="auth-form" (ngSubmit)="submitSignUp()">
+  <nz-card class="auth-card">
+    <ng-container *ngIf="cardStep === 'credentials'; else deviceStep">
+      <h2 class="card-title">{{ authMode === 'signIn' ? 'ورود به حساب' : 'ثبت‌نام کاربر جدید' }}</h2>
+      <p class="card-subtitle">
+        {{ authMode === 'signIn' ? 'برای ورود، نام کاربری و رمز عبور خود را وارد کنید.' : 'برای ساخت حساب جدید، اطلاعات زیر را تکمیل کنید.' }}
+      </p>
+
+      <ng-container *ngIf="authMode === 'signIn'; else signUpFormTpl">
+        <form class="credential-form" (ngSubmit)="submitSignIn()">
           <label class="form-field">
-            <span class="label">نام کاربری</span>
-            <input nz-input name="signup-username" [(ngModel)]="signUpForm.username" required placeholder="user1" />
+            <span>نام کاربری</span>
+            <input nz-input name="signin-username" [(ngModel)]="signInForm.username" required />
           </label>
+
           <label class="form-field">
-            <span class="label">ایمیل</span>
-            <input nz-input type="email" name="signup-email" [(ngModel)]="signUpForm.email" required placeholder="user@example.com" />
+            <span>رمز عبور</span>
+            <input nz-input type="password" name="signin-password" [(ngModel)]="signInForm.password" required />
           </label>
-          <label class="form-field">
-            <span class="label">رمز عبور</span>
-            <input nz-input type="password" name="signup-password" [(ngModel)]="signUpForm.password" required placeholder="رمز عبور" />
-          </label>
-          <button nz-button nzType="primary" [nzLoading]="loading.signUp" type="submit">
-            ثبت‌نام
-          </button>
+
+          <button nz-button nzType="primary" type="submit" [nzLoading]="loading.signIn">ورود</button>
         </form>
-      </nz-card>
-    </div>
-    <div nz-col [nzSpan]="24" [nzLg]="12">
-      <nz-card nzTitle="ورود کاربر">
-        <form class="auth-form" (ngSubmit)="submitSignIn()">
+      </ng-container>
+
+      <ng-template #signUpFormTpl>
+        <form class="credential-form" (ngSubmit)="submitSignUp()">
           <label class="form-field">
-            <span class="label">نام کاربری</span>
-            <input nz-input name="signin-username" [(ngModel)]="signInForm.username" required placeholder="user1" />
+            <span>نام کاربری</span>
+            <input nz-input name="signup-username" [(ngModel)]="signUpForm.username" required />
           </label>
+
           <label class="form-field">
-            <span class="label">رمز عبور</span>
-            <input nz-input type="password" name="signin-password" [(ngModel)]="signInForm.password" required placeholder="رمز عبور" />
+            <span>ایمیل</span>
+            <input nz-input type="email" name="signup-email" [(ngModel)]="signUpForm.email" required />
           </label>
-          <button nz-button nzType="primary" [nzLoading]="loading.signIn" type="submit">
-            ورود
-          </button>
+
+          <label class="form-field">
+            <span>رمز عبور</span>
+            <input nz-input type="password" name="signup-password" [(ngModel)]="signUpForm.password" required />
+          </label>
+
+          <button nz-button nzType="primary" type="submit" [nzLoading]="loading.signUp">ثبت‌نام</button>
         </form>
-      </nz-card>
-    </div>
-  </div>
-
-  <nz-card nzTitle="وضعیت احراز هویت" class="session-card">
-    <div class="session-header">
-      <div class="next-step">
-        <span class="label">گام بعدی:</span>
-        <strong>{{ nextStepDescription }}</strong>
-      </div>
-      <nz-tag *ngIf="state?.auth_stage" nzColor="blue">{{ state?.auth_stage }}</nz-tag>
-      <nz-tag *ngIf="fullyAuthenticated" nzColor="green">احراز هویت نهایی شد</nz-tag>
-    </div>
-
-    <div class="session-body">
-      <div class="session-info" *ngIf="session; else guestInfo">
-        <p><strong>کاربر:</strong> {{ session?.username }}</p>
-        <p><strong>ایمیل:</strong> {{ session?.email }}</p>
-        <p><strong>شناسه کاربر:</strong> {{ session?.id }}</p>
-        <p><strong>ایجاد شده در:</strong> {{ session?.created_at | date: 'medium' }}</p>
-      </div>
-      <ng-template #guestInfo>
-        <p>هنوز اطلاعات کاربری دریافت نشده است. ابتدا ثبت‌نام یا ورود را انجام دهید.</p>
       </ng-template>
-    </div>
 
-    <div class="api-field">
-      <label>
-        <span>آدرس پایه API</span>
-        <input
-          nz-input
-          [(ngModel)]="apiBase"
-          [ngModelOptions]="{ standalone: true }"
-          placeholder="http://localhost:8001/api"
-        />
-      </label>
-    </div>
+      <div class="switch-auth">
+        <button nz-button nzType="link" type="button" (click)="authMode === 'signIn' ? switchToSignUp() : switchToSignIn()">
+          {{ authMode === 'signIn' ? 'حسابی ندارید؟ ثبت‌نام کنید.' : 'حساب دارید؟ وارد شوید.' }}
+        </button>
+      </div>
+    </ng-container>
 
-    <div class="session-actions">
-      <button nz-button nzType="default" (click)="refreshSession()" [nzLoading]="loading.session">
-        به‌روزرسانی وضعیت
-      </button>
+    <ng-template #deviceStep>
+      <h2 class="card-title">احراز هویت دستگاه</h2>
 
-      <ng-container *ngIf="requiresRegistration">
-        <div class="device-controls">
+      <ng-container *ngIf="fullyAuthenticated; else pendingDevice">
+        <p class="success-message">احراز هویت کاربر و دستگاه با موفقیت تکمیل شد.</p>
+      </ng-container>
+
+      <ng-template #pendingDevice>
+        <p class="card-subtitle">{{ nextStepDescription }}</p>
+
+        <div class="device-section" *ngIf="requiresRegistration">
+          <p>برای تکمیل ورود، دستگاه خود را ثبت کنید.</p>
           <input
             nz-input
             placeholder="نام دستگاه (اختیاری)"
@@ -102,45 +74,20 @@
             ثبت دستگاه
           </button>
         </div>
-      </ng-container>
 
-      <button
-        nz-button
-        nzType="primary"
-        nzGhost
-        *ngIf="requiresAuthentication"
-        (click)="authenticateDevice()"
-        [nzLoading]="loading.authenticate"
-      >
-        احراز هویت با دستگاه
-      </button>
-
-      <p class="success-message" *ngIf="fullyAuthenticated">
-        کاربر با موفقیت احراز هویت شد و نیازی به اقدام دیگری نیست.
-      </p>
-    </div>
-  </nz-card>
-
-  <nz-card nzTitle="گزارش رویدادها" class="log-card">
-    <div class="log-toolbar">
-      <button nz-button nzType="default" nzGhost (click)="clearLogs()">پاک‌سازی گزارش‌ها</button>
-    </div>
-    <div class="log-container" #logContainer>
-      <ng-container *ngIf="logs.length; else emptyLog">
-        <div class="log-entry" *ngFor="let entry of logs" [ngClass]="entry.level">
-          <div class="log-entry__header">
-            <span class="timestamp">{{ entry.timestamp }}</span>
-            <nz-tag [nzColor]="entry.level === 'error' ? 'red' : entry.level === 'success' ? 'green' : 'blue'">
-              {{ entry.level | uppercase }}
-            </nz-tag>
-          </div>
-          <p class="message">{{ entry.message }}</p>
-          <pre class="detail" *ngIf="entry.detail">{{ entry.detail }}</pre>
+        <div class="device-section" *ngIf="requiresAuthentication">
+          <p>برای ادامه، از دستگاه ثبت شده خود جهت احراز هویت استفاده کنید.</p>
+          <button nz-button nzType="primary" (click)="authenticateDevice()" [nzLoading]="loading.authenticate">
+            شروع احراز هویت دستگاه
+          </button>
         </div>
-      </ng-container>
-      <ng-template #emptyLog>
-        <p class="empty-state">هنوز رویدادی ثبت نشده است.</p>
+
+        <div class="refresh-row">
+          <button nz-button nzType="default" (click)="refreshSession()" [nzLoading]="loading.session">
+            به‌روزرسانی وضعیت
+          </button>
+        </div>
       </ng-template>
-    </div>
+    </ng-template>
   </nz-card>
 </div>

--- a/src/app/features/dashboard/components/temp-auth/temp-auth.component.html
+++ b/src/app/features/dashboard/components/temp-auth/temp-auth.component.html
@@ -1,511 +1,122 @@
-<div class="container">
-    <h1>🔐 WebAuthn Test Client <span>Exercise each /api/webauthn/* endpoint</span></h1>
-
-    <section class="panel">
-      <div class="grid">
-        <label>
-          API base URL
-          <input id="apiBase" type="url" value="http://localhost:8001/api" placeholder="http://localhost:8001/api"/>
-        </label>
-        <label>
-          Authorization header
-          <textarea id="authToken" rows="3" placeholder="Bearer &lt;jwt&gt;">Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwidXNlcm5hbWUiOiJtb2hhbW1hZCIsImF1dGhfc3RhZ2UiOiJwYXNzd29yZF92ZXJpZmllZCIsIndlYmF1dGhuX3JlcXVpcmVkIjp0cnVlLCJ3ZWJhdXRobl9jb21wbGV0ZWQiOmZhbHNlLCJleHAiOjE3NTg5MTAzNzJ9.uIehYsRMdzxf4rBqm9W6ddkfOknP3WpSJV-KDdbC1hk</textarea>
-        </label>
-      </div>
-      <div class="actions">
-        <button type="button" id="btnRegister">Start registration</button>
-        <button type="button" id="btnAuthenticate" class="secondary">Start authentication</button>
-        <button type="button" id="btnListDevices" class="ghost">List devices</button>
-        <button type="button" id="btnGetMe" class="ghost">Call /auth/me</button>
-        <button type="button" id="btnClearLog" class="ghost">Clear log</button>
-      </div>
-    </section>
-
-    <section class="grid">
-      <div class="panel">
-        <h2>Delete a device</h2>
-        <label>
-          Credential ID (Base64URL from /webauthn/devices)
-          <input id="credentialId" type="text" placeholder="Paste encoded credential id"/>
-        </label>
-        <button type="button" id="btnDelete" class="ghost">Delete credential</button>
-      </div>
-      <div class="panel">
-        <h2>Registered devices</h2>
-        <div id="devices" class="devices-list"></div>
-      </div>
-    </section>
-
-    <section>
-      <h2>Logs</h2>
-      <div id="log"></div>
-    </section>
+<div class="temp-auth-page">
+  <div class="page-header">
+    <h1>
+      🔐 کلاینت آزمایشی WebAuthn
+      <span>امکان تست تمامی سرویس‌های /api/webauthn/* در محیط مرورگر</span>
+    </h1>
+    <p>
+      از این صفحه برای ثبت، احراز هویت و مدیریت دستگاه‌های WebAuthn استفاده کنید. پیکربندی درخواست‌ها را مطابق با محیط
+      اجرایی خود تنظیم نموده و سپس عملیات مورد نظر را آغاز کنید.
+    </p>
   </div>
 
-  <script>
-    const logView = document.getElementById("log");
-    const devicesView = document.getElementById("devices");
+  <div nz-row [nzGutter]="[16, 16]">
+    <div nz-col [nzSpan]="24" [nzLg]="14">
+      <nz-card nzTitle="پیکربندی درخواست" class="config-card">
+        <div class="config-grid">
+          <label class="form-field">
+            <span class="label-text">آدرس پایه API</span>
+            <input nz-input type="url" [(ngModel)]="apiBase" placeholder="http://localhost:8001/api" />
+          </label>
 
-    function timestamp() {
-      return new Date().toISOString().replace("T", " ").replace("Z", "");
-    }
+          <label class="form-field full-width">
+            <span class="label-text">هدر احراز هویت</span>
+            <textarea
+              nz-input
+              rows="3"
+              [(ngModel)]="authToken"
+              placeholder="Bearer &lt;jwt&gt;"
+            ></textarea>
+          </label>
+        </div>
 
-    function log(message, data, level = "info") {
-      const meta = data !== undefined ? data : "";
-      if (data instanceof Error) {
-        console.error("[", timestamp(), "]", message, data);
-      } else {
-        console.log("[", timestamp(), "]", message, data ?? "");
-      }
+        <div class="action-row">
+          <button nz-button nzType="primary" (click)="startRegistration()" [nzLoading]="loading.register">
+            شروع ثبت‌نام
+          </button>
+          <button nz-button nzType="default" (click)="startAuthentication()" [nzLoading]="loading.authenticate">
+            شروع احراز هویت
+          </button>
+          <button nz-button nzType="default" nzGhost (click)="listDevices()" [nzLoading]="loading.list">
+            به‌روزرسانی دستگاه‌ها
+          </button>
+          <button nz-button nzType="default" nzGhost (click)="getMe()" [nzLoading]="loading.getMe">
+            دریافت اطلاعات کاربر
+          </button>
+        </div>
+      </nz-card>
+    </div>
 
-      const entry = document.createElement("div");
-      entry.className = `log-entry ${level}`;
-      let content = `[${timestamp()}] ${message}`;
-      if (meta instanceof Error) {
-        content += ` -> ${meta.name}: ${meta.message}`;
-      } else if (meta) {
-        try {
-          content += `\n${JSON.stringify(meta, null, 2)}`;
-        } catch (err) {
-          content += "\n(unserializable data)";
-        }
-      }
-      entry.textContent = content;
-      logView.appendChild(entry);
-      logView.scrollTop = logView.scrollHeight;
-    }
+    <div nz-col [nzSpan]="24" [nzLg]="10" class="side-column">
+      <nz-card nzTitle="حذف دستگاه" class="delete-card">
+        <p class="card-helper">شناسه Credential را از لیست دستگاه‌ها یا پاسخ سرویس دریافت کرده و در این قسمت وارد کنید.</p>
+        <div class="delete-grid">
+          <input
+            nz-input
+            [(ngModel)]="credentialId"
+            placeholder="شناسه Credential"
+            aria-label="شناسه Credential"
+          />
+          <button
+            nz-button
+            nzType="default"
+            nzDanger
+            (click)="deleteDevice()"
+            [nzLoading]="loading.delete"
+          >
+            حذف دستگاه
+          </button>
+        </div>
+      </nz-card>
 
-    function logError(message, error) {
-      log(message, error, "error");
-    }
+      <nz-card nzTitle="دستگاه‌های ثبت‌شده" class="devices-card" [nzLoading]="loading.list">
+        <ng-container *ngIf="devices.length; else emptyDevices">
+          <div class="device-card" *ngFor="let device of devices">
+            <div class="device-header">
+              <h3>{{ device.device_name || 'بدون نام' }}</h3>
+              <nz-tag nzColor="blue">{{ device.sign_count }} بار استفاده</nz-tag>
+            </div>
+            <dl>
+              <div>
+                <dt>Credential ID</dt>
+                <dd>{{ device.credential_id }}</dd>
+              </div>
+              <div>
+                <dt>تاریخ ایجاد</dt>
+                <dd>{{ device.created_at || '—' }}</dd>
+              </div>
+              <div>
+                <dt>آخرین استفاده</dt>
+                <dd>{{ device.last_used || '—' }}</dd>
+              </div>
+            </dl>
+          </div>
+        </ng-container>
+        <ng-template #emptyDevices>
+          <p class="empty-state">تا کنون دستگاهی ثبت نشده است.</p>
+        </ng-template>
+      </nz-card>
+    </div>
+  </div>
 
-    function logSuccess(message, data) {
-      log(message, data, "success");
-    }
-
-    const bufferDecode = (value) =>
-      Uint8Array.from(
-        window.atob(value.replace(/_/g, "/").replace(/-/g, "+")),
-        (c) => c.charCodeAt(0)
-      );
-
-    const bufferEncode = (value) =>
-      window
-        .btoa(String.fromCharCode(...new Uint8Array(value)))
-        .replace(/\+/g, "-")
-        .replace(/\//g, "_")
-        .replace(/=+$/g, "");
-
-    const toBufferSource = (value) => {
-      if (!value) {
-        return value;
-      }
-
-      if (value instanceof ArrayBuffer) {
-        return value;
-      }
-
-      if (ArrayBuffer.isView(value)) {
-        return value;
-      }
-
-      if (typeof value === "string") {
-        return bufferDecode(value);
-      }
-
-      throw new TypeError("Unsupported credential buffer value");
-    };
-
-    function getApiBase() {
-      const url = document.getElementById("apiBase").value.trim().replace(/\/$/, "");
-      log("Using API base", url);
-      return url;
-    }
-
-    function getAuthHeaders() {
-      const headers = { "Content-Type": "application/json" };
-      const token = document.getElementById("authToken").value.trim();
-      if (token) {
-        headers["Authorization"] = token;
-      }
-      log("Prepared headers", headers);
-      return headers;
-    }
-
-    async function readJson(response) {
-      const text = await response.text();
-      try {
-        return text ? JSON.parse(text) : {};
-      } catch (err) {
-        logError("Failed to parse JSON", err);
-        throw err;
-      }
-    }
-
-    function convertProperty(object, from, to) {
-      if (object && Object.hasOwn(object, from)) {
-        object[to] = object[from];
-        delete object[from];
-      }
-    }
-
-    function normaliseRegistrationOptions(publicKey) {
-      log("Normalising registration options", publicKey);
-      const copy = structuredClone(publicKey);
-      copy.challenge = bufferDecode(copy.challenge);
-      if (copy.user?.id) {
-        copy.user.id = bufferDecode(copy.user.id);
-      }
-      const exclude = copy.exclude_credentials ?? copy.excludeCredentials ?? [];
-      exclude.forEach((cred) => {
-        cred.id = bufferDecode(cred.id);
-      });
-      convertProperty(copy, "pub_key_cred_params", "pubKeyCredParams");
-      convertProperty(copy, "authenticator_selection", "authenticatorSelection");
-      convertProperty(copy, "exclude_credentials", "excludeCredentials");
-      if (copy.authenticatorSelection) {
-        convertProperty(copy.authenticatorSelection, "user_verification", "userVerification");
-        convertProperty(copy.authenticatorSelection, "resident_key", "residentKey");
-        convertProperty(copy.authenticatorSelection, "require_resident_key", "requireResidentKey");
-      }
-      if (copy.user) {
-        convertProperty(copy.user, "display_name", "displayName");
-      }
-      logSuccess("Registration options ready", copy);
-      return copy;
-    }
-
-    function normaliseAuthenticationOptions(publicKey) {
-      log("Normalising authentication options", publicKey);
-      const copy = structuredClone(publicKey);
-      copy.challenge = bufferDecode(copy.challenge);
-
-      const allowCredentials = (copy.allow_credentials ?? copy.allowCredentials ?? []).map((cred) => ({
-        ...cred,
-        id: toBufferSource(cred.id)
-      }));
-      copy.allowCredentials = allowCredentials;
-      delete copy.allow_credentials;
-
-      convertProperty(copy, "allow_credentials", "allowCredentials");
-      if (copy.authenticator_selection) {
-        convertProperty(copy, "authenticator_selection", "authenticatorSelection");
-      }
-      if (copy.authenticatorSelection) {
-        convertProperty(copy.authenticatorSelection, "user_verification", "userVerification");
-        convertProperty(copy.authenticatorSelection, "resident_key", "residentKey");
-        convertProperty(copy.authenticatorSelection, "require_resident_key", "requireResidentKey");
-      }
-      logSuccess("Authentication options ready", copy);
-      return copy;
-    }
-
-    async function fetchWithLogging(url, options) {
-      let bodyForLog;
-      if (options?.body) {
-        try {
-          bodyForLog = JSON.parse(options.body);
-        } catch (err) {
-          bodyForLog = "(body not JSON)";
-        }
-      }
-      log(`HTTP ${options?.method || "GET"} ${url}`, bodyForLog);
-      const response = await fetch(url, options);
-      logSuccess(`HTTP ${response.status} ${url}`);
-      return response;
-    }
-
-    async function deleteCredentialById(credentialId) {
-      const response = await fetchWithLogging(`${getApiBase()}/webauthn/devices/${encodeURIComponent(credentialId)}`, {
-        method: "DELETE",
-        headers: getAuthHeaders()
-      });
-
-      if (!response.ok) {
-        const body = await response.text();
-        logError("delete failed", new Error(body || response.statusText));
-        return false;
-      }
-
-      logSuccess("Device deleted", credentialId);
-      return true;
-    }
-
-    async function handleExcludedCredentials(encodedIds) {
-      if (!encodedIds.length) {
-        return true;
-      }
-
-      logError("Authenticator already registered", { encodedIds });
-      const message =
-        `This authenticator already has ${encodedIds.length} credential(s) registered.\n` +
-        `Chrome will block duplicate registrations until you remove them.\n\n` +
-        `Click OK to delete the stored credential(s) and retry, or Cancel to abort.`;
-      const confirmed = window.confirm(message);
-      if (!confirmed) {
-        log("Registration aborted because existing credentials were kept.");
-        return false;
-      }
-
-      for (const credentialId of encodedIds) {
-        const deleted = await deleteCredentialById(credentialId);
-        if (!deleted) {
-          logError("Failed to delete credential automatically", new Error(credentialId));
-          return false;
-        }
-      }
-
-      await listDevices();
-      logSuccess("Existing credentials removed. Retry registration to continue.");
-      return true;
-    }
-
-    async function startRegistration(retrying = false) {
-      log("register() invoked");
-      try {
-        const response = await fetchWithLogging(`${getApiBase()}/webauthn/registration/start`, {
-          method: "POST",
-          headers: getAuthHeaders(),
-          body: JSON.stringify({})
-        });
-
-        if (!response.ok) {
-          const body = await response.text();
-          logError("registration/start failed", new Error(body || response.statusText));
-          return;
-        }
-
-        const { publicKey } = await readJson(response);
-        const excludedIds = (publicKey.exclude_credentials || publicKey.excludeCredentials || []).map((cred) => cred.id);
-        if (excludedIds.length) {
-          const cleared = await handleExcludedCredentials(excludedIds);
-          if (!cleared) {
-            return;
-          }
-          if (!retrying) {
-            log("Retrying registration after removing stored credential(s)");
-            return startRegistration(true);
-          }
-        }
-
-        const options = normaliseRegistrationOptions(publicKey);
-        log("Calling navigator.credentials.create", options);
-        const credential = await navigator.credentials.create({ publicKey: options });
-        logSuccess("Credential created", credential);
-
-        const payload = {
-          id: credential.id,
-          rawId: bufferEncode(credential.rawId),
-          type: credential.type,
-          response: {
-            clientDataJSON: bufferEncode(credential.response.clientDataJSON),
-            attestationObject: bufferEncode(credential.response.attestationObject)
-          }
-        };
-        log("Sending registration complete payload", payload);
-
-        const finish = await fetchWithLogging(`${getApiBase()}/webauthn/registration/complete`, {
-          method: "POST",
-          headers: getAuthHeaders(),
-          body: JSON.stringify(payload)
-        });
-
-        const result = await readJson(finish);
-        if (!finish.ok) {
-          logError("registration/complete failed", new Error(JSON.stringify(result)));
-          return;
-        }
-
-        logSuccess("Registration completed", result);
-        alert(`Registration successful!\n\n${JSON.stringify(result, null, 2)}`);
-
-        await listDevices();
-      } catch (error) {
-        if (error?.name === "InvalidStateError") {
-          logError("Authenticator reports credential already registered. Remove it then retry.", error);
-          alert("This authenticator already has a passkey for this site. Remove the stored credential (use the Delete button) and try again.");
-        } else if (error?.name === "NotAllowedError") {
-          logError("Registration was cancelled or timed out.", error);
-        } else {
-          logError("Exception in startRegistration", error);
-        }
-      }
-    }
-
-    async function startAuthentication() {
-      log("authenticate() invoked");
-      try {
-        const response = await fetchWithLogging(`${getApiBase()}/webauthn/authentication/start`, {
-          method: "POST",
-          headers: getAuthHeaders(),
-          body: JSON.stringify({})
-        });
-
-        if (!response.ok) {
-          const body = await response.text();
-          logError("authentication/start failed", new Error(body || response.statusText));
-          return;
-        }
-
-        const { publicKey } = await readJson(response);
-        const options = normaliseAuthenticationOptions(publicKey);
-        log("Calling navigator.credentials.get", options);
-        const credential = await navigator.credentials.get({ publicKey: options });
-        logSuccess("Assertion obtained", credential);
-
-        const payload = {
-          id: credential.id,
-          rawId: bufferEncode(credential.rawId),
-          type: credential.type,
-          response: {
-            authenticatorData: bufferEncode(credential.response.authenticatorData),
-            clientDataJSON: bufferEncode(credential.response.clientDataJSON),
-            signature: bufferEncode(credential.response.signature),
-            userHandle: credential.response.userHandle ? bufferEncode(credential.response.userHandle) : null
-          }
-        };
-        log("Sending authentication complete payload", payload);
-
-        const finish = await fetchWithLogging(`${getApiBase()}/webauthn/authentication/complete`, {
-          method: "POST",
-          headers: getAuthHeaders(),
-          body: JSON.stringify(payload)
-        });
-
-        const result = await readJson(finish);
-        if (!finish.ok) {
-          logError("authentication/complete failed", new Error(JSON.stringify(result)));
-          return;
-        }
-
-        logSuccess("Authentication completed", result);
-        alert(`Authentication successful!\n\n${JSON.stringify(result, null, 2)}`);
-      } catch (error) {
-        if (error?.name === "NotAllowedError") {
-          logError("Authentication was cancelled or timed out.", error);
-        } else {
-          logError("Exception in startAuthentication", error);
-        }
-      }
-    }
-
-    async function listDevices() {
-      log("listDevices() invoked");
-      try {
-        const response = await fetchWithLogging(`${getApiBase()}/webauthn/devices`, {
-          method: "GET",
-          headers: getAuthHeaders()
-        });
-
-        const result = await readJson(response);
-        if (!response.ok) {
-          logError("devices list failed", new Error(JSON.stringify(result)));
-          return;
-        }
-
-        devicesView.replaceChildren();
-        if (!result.length) {
-          const empty = document.createElement("p");
-          empty.textContent = "No WebAuthn devices registered.";
-          devicesView.appendChild(empty);
-        }
-
-        result.forEach((device) => {
-          const card = document.createElement("div");
-          card.className = "device-card";
-          card.innerHTML = `
-            <div><strong>Device:</strong> ${device.device_name || "Unnamed"}</div>
-            <div><strong>Credential ID:</strong> ${device.credential_id}</div>
-            <div><strong>Sign count:</strong> ${device.sign_count}</div>
-            <div><strong>Created:</strong> ${device.created_at || ""}</div>
-            <div><strong>Last used:</strong> ${device.last_used || ""}</div>
-          `;
-          devicesView.appendChild(card);
-        });
-
-        logSuccess("Devices loaded", result);
-      } catch (error) {
-        logError("Exception in listDevices", error);
-      }
-    }
-
-    async function deleteDevice() {
-      log("deleteDevice() invoked");
-      const credentialId = document.getElementById("credentialId").value.trim();
-      if (!credentialId) {
-        logError("Credential ID required", new Error("Please provide a credential id"));
-        return;
-      }
-
-      try {
-        const deleted = await deleteCredentialById(credentialId);
-        if (!deleted) {
-          return;
-        }
-        await listDevices();
-      } catch (error) {
-        logError("Exception in deleteDevice", error);
-      }
-    }
-
-    async function getMe() {
-      log("getMe() invoked");
-      try {
-        const response = await fetchWithLogging(`${getApiBase()}/authentication/me`, {
-          method: "GET",
-          headers: getAuthHeaders()
-        });
-
-        const result = await readJson(response);
-        if (!response.ok) {
-          logError("/auth/me failed", new Error(JSON.stringify(result)));
-          return;
-        }
-
-        logSuccess("/auth/me response", result);
-        alert(`User info:\n\n${JSON.stringify(result, null, 2)}`);
-      } catch (error) {
-        logError("Exception in getMe", error);
-      }
-    }
-
-    function clearLog() {
-      log("clearLog() invoked");
-      logView.replaceChildren();
-    }
-
-    document.getElementById("btnRegister").addEventListener("click", () => {
-      log("Register button clicked");
-      startRegistration();
-    });
-
-    document.getElementById("btnAuthenticate").addEventListener("click", () => {
-      log("Authenticate button clicked");
-      startAuthentication();
-    });
-
-    document.getElementById("btnListDevices").addEventListener("click", () => {
-      log("List devices button clicked");
-      listDevices();
-    });
-
-    document.getElementById("btnDelete").addEventListener("click", () => {
-      log("Delete button clicked");
-      deleteDevice();
-    });
-
-    document.getElementById("btnGetMe").addEventListener("click", () => {
-      log("GetMe button clicked");
-      getMe();
-    });
-
-    document.getElementById("btnClearLog").addEventListener("click", () => {
-      log("Clear log button clicked");
-      clearLog();
-    });
-
-    document.addEventListener("DOMContentLoaded", () => {
-      log("DOMContentLoaded event fired");
-      listDevices();
-    });
-  </script>
+  <nz-card nzTitle="گزارش‌ها" class="log-card">
+    <div class="log-toolbar">
+      <button nz-button nzType="default" nzGhost (click)="clearLog()">پاک‌سازی گزارش‌ها</button>
+    </div>
+    <div class="log-container" #logContainer>
+      <ng-container *ngIf="logs.length; else emptyLogs">
+        <div class="log-entry" *ngFor="let entry of logs" [ngClass]="entry.level">
+          <div class="log-entry__header">
+            <span class="timestamp">{{ entry.timestamp }}</span>
+            <nz-tag [nzColor]="logColor(entry.level)">{{ entry.level | uppercase }}</nz-tag>
+          </div>
+          <p class="message">{{ entry.message }}</p>
+          <pre class="detail" *ngIf="entry.detail">{{ entry.detail }}</pre>
+        </div>
+      </ng-container>
+      <ng-template #emptyLogs>
+        <p class="empty-state">هنوز گزارشی ثبت نشده است.</p>
+      </ng-template>
+    </div>
+  </nz-card>
+</div>

--- a/src/app/features/dashboard/components/temp-auth/temp-auth.component.scss
+++ b/src/app/features/dashboard/components/temp-auth/temp-auth.component.scss
@@ -1,223 +1,132 @@
 .temp-auth-page {
+  min-height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 24px;
-  background: #f5f7fa;
-  min-height: 100%;
+  justify-content: center;
+  align-items: center;
+  padding: 48px 16px;
+  background: #f5f6fa;
+  gap: 24px;
 
-  .page-header {
-    background: #ffffff;
-    border-radius: 12px;
-    padding: 24px;
-    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  .status-message {
+    margin: 0;
+    font-size: 16px;
+    text-align: center;
+    color: #334155;
+    max-width: 420px;
+    line-height: 1.8;
+  }
+}
 
-    h1 {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-      margin: 0 0 12px;
-      color: #0f172a;
-      font-weight: 700;
+.auth-card {
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+  border-radius: 20px;
+  overflow: hidden;
 
-      span {
-        font-size: 14px;
-        color: #64748b;
-        font-weight: 400;
-      }
-    }
-
-    p {
-      margin: 0;
-      color: #475569;
-      line-height: 1.8;
-    }
+  .card-title {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 700;
+    color: #0f172a;
+    text-align: center;
   }
 
-  .forms-row {
-    .auth-form {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-
-      .form-field {
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-
-        .label {
-          font-size: 13px;
-          color: #475569;
-          font-weight: 600;
-        }
-      }
-
-      button {
-        align-self: flex-start;
-      }
-    }
+  .card-subtitle {
+    margin: 12px 0 24px;
+    text-align: center;
+    color: #64748b;
+    line-height: 1.7;
   }
 
-  .session-card {
+  .credential-form {
     display: flex;
     flex-direction: column;
     gap: 16px;
 
-    .session-header {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: 12px;
-
-      .next-step {
-        display: flex;
-        flex-direction: row;
-        align-items: baseline;
-        gap: 8px;
-        font-size: 14px;
-
-        .label {
-          color: #475569;
-        }
-
-        strong {
-          color: #0f172a;
-        }
-      }
-    }
-
-    .session-body {
-      background: #f8fafc;
-      border-radius: 8px;
-      padding: 16px;
-      font-size: 14px;
-      line-height: 1.8;
-
-      .session-info {
-        display: grid;
-        gap: 4px;
-      }
-    }
-
-    .api-field {
+    .form-field {
       display: flex;
       flex-direction: column;
       gap: 8px;
 
       span {
-        font-size: 12px;
-        color: #64748b;
+        font-size: 14px;
+        color: #475569;
         font-weight: 600;
       }
     }
 
-    .session-actions {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-
-      .device-controls {
-        display: flex;
-        flex-direction: row;
-        gap: 8px;
-        flex-wrap: wrap;
-
-        input {
-          min-width: 220px;
-        }
-      }
-
-      .success-message {
-        margin: 0;
-        color: #0f766e;
-        background: #ecfdf5;
-        border-radius: 8px;
-        padding: 12px;
-        font-size: 14px;
-      }
+    button[nz-button] {
+      margin-top: 8px;
+      width: 100%;
+      height: 44px;
+      font-size: 16px;
     }
   }
 
-  .log-card {
+  .switch-auth {
+    margin-top: 12px;
+    text-align: center;
+
+    button[nz-button] {
+      padding: 0;
+      font-size: 14px;
+    }
+  }
+
+  .device-section {
     display: flex;
     flex-direction: column;
     gap: 12px;
+    margin-top: 20px;
+    text-align: center;
 
-    .log-toolbar {
-      display: flex;
-      justify-content: flex-end;
+    input[nz-input] {
+      text-align: center;
     }
 
-    .log-container {
-      max-height: 360px;
-      overflow-y: auto;
-      background: #0f172a;
-      border-radius: 12px;
-      padding: 16px;
-      color: #e2e8f0;
-      font-family: 'Fira Code', 'Courier New', monospace;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-
-      .empty-state {
-        margin: 0;
-        text-align: center;
-        color: #94a3b8;
-      }
-
-      .log-entry {
-        background: rgba(15, 23, 42, 0.6);
-        border-radius: 8px;
-        padding: 12px;
-        border: 1px solid rgba(148, 163, 184, 0.2);
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-
-        &.error {
-          border-color: rgba(239, 68, 68, 0.4);
-        }
-
-        &.success {
-          border-color: rgba(16, 185, 129, 0.4);
-        }
-
-        .log-entry__header {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          font-size: 12px;
-          color: #cbd5f5;
-
-          .timestamp {
-            font-family: inherit;
-            letter-spacing: 0.5px;
-          }
-        }
-
-        .message {
-          margin: 0;
-          font-size: 14px;
-          color: #f8fafc;
-        }
-
-        .detail {
-          margin: 0;
-          white-space: pre-wrap;
-          word-break: break-word;
-          background: rgba(15, 23, 42, 0.5);
-          border-radius: 8px;
-          padding: 8px;
-          color: #cbd5f5;
-        }
-      }
+    button[nz-button] {
+      align-self: center;
+      min-width: 220px;
+      height: 44px;
+      font-size: 15px;
     }
+  }
+
+  .refresh-row {
+    display: flex;
+    justify-content: center;
+    margin-top: 28px;
+
+    button[nz-button] {
+      min-width: 200px;
+      height: 40px;
+    }
+  }
+
+  .success-message {
+    margin: 24px 0 8px;
+    padding: 16px;
+    background: #ecfdf5;
+    color: #047857;
+    border-radius: 12px;
+    text-align: center;
+    font-weight: 600;
+    line-height: 1.8;
   }
 }
 
-@media (max-width: 992px) {
-  .temp-auth-page {
-    padding: 16px;
+@media (max-width: 480px) {
+  .auth-card {
+    border-radius: 16px;
+
+    .card-title {
+      font-size: 20px;
+    }
+
+    .card-subtitle {
+      font-size: 14px;
+    }
   }
 }

--- a/src/app/features/dashboard/components/temp-auth/temp-auth.component.scss
+++ b/src/app/features/dashboard/components/temp-auth/temp-auth.component.scss
@@ -1,0 +1,226 @@
+.temp-auth-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+  background: var(--page-background, #f5f5f5);
+
+  .page-header {
+    background: #fff;
+    border-radius: 16px;
+    padding: 24px 28px;
+    box-shadow: 0 12px 32px -12px rgba(15, 23, 42, 0.18);
+
+    h1 {
+      margin: 0;
+      font-size: 1.8rem;
+      font-weight: 700;
+      color: #0f172a;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+
+      span {
+        font-size: 0.9rem;
+        font-weight: 500;
+        color: #64748b;
+      }
+    }
+
+    p {
+      margin: 16px 0 0;
+      color: #475569;
+      line-height: 1.7;
+    }
+  }
+
+  nz-card {
+    border-radius: 16px;
+    box-shadow: 0 12px 32px -18px rgba(15, 23, 42, 0.25);
+  }
+
+  .config-card {
+    .config-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+
+      .form-field {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+
+        .label-text {
+          font-weight: 600;
+          color: #0f172a;
+        }
+
+        textarea[nz-input] {
+          resize: vertical;
+        }
+      }
+
+      .full-width {
+        grid-column: 1 / -1;
+      }
+    }
+
+    .action-row {
+      margin-top: 20px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+  }
+
+  .side-column {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .delete-card {
+    .card-helper {
+      margin-bottom: 12px;
+      color: #64748b;
+    }
+
+    .delete-grid {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 12px;
+
+      @media (max-width: 768px) {
+        grid-template-columns: 1fr;
+      }
+    }
+  }
+
+  .devices-card {
+    .device-card {
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      padding: 16px;
+      margin-bottom: 12px;
+      background: #fff;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+      &:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 14px 28px -18px rgba(15, 23, 42, 0.25);
+      }
+
+      .device-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 12px;
+
+        h3 {
+          margin: 0;
+          font-size: 1.1rem;
+          color: #0f172a;
+        }
+      }
+
+      dl {
+        margin: 0;
+        display: grid;
+        gap: 8px;
+
+        div {
+          display: grid;
+          grid-template-columns: 140px 1fr;
+          gap: 12px;
+
+          dt {
+            margin: 0;
+            font-weight: 600;
+            color: #475569;
+          }
+
+          dd {
+            margin: 0;
+            color: #0f172a;
+            word-break: break-all;
+            direction: ltr;
+          }
+        }
+      }
+    }
+  }
+
+  .log-card {
+    .log-toolbar {
+      display: flex;
+      justify-content: flex-end;
+      margin-bottom: 12px;
+    }
+
+    .log-container {
+      max-height: 340px;
+      overflow-y: auto;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      padding: 16px;
+      background: #0f172a;
+    }
+
+    .log-entry {
+      background: rgba(15, 23, 42, 0.7);
+      border-radius: 12px;
+      padding: 12px 14px;
+      margin-bottom: 12px;
+      color: #e2e8f0;
+      border-left: 3px solid transparent;
+
+      &__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 8px;
+        gap: 12px;
+
+        .timestamp {
+          font-family: 'Roboto Mono', monospace;
+          font-size: 0.85rem;
+          color: rgba(226, 232, 240, 0.7);
+        }
+      }
+
+      .message {
+        margin: 0;
+        font-weight: 600;
+      }
+
+      .detail {
+        margin: 8px 0 0;
+        font-size: 0.85rem;
+        line-height: 1.5;
+        color: rgba(226, 232, 240, 0.9);
+        white-space: pre-wrap;
+        direction: ltr;
+      }
+
+      &.info {
+        border-left-color: #38bdf8;
+      }
+
+      &.success {
+        border-left-color: #22c55e;
+      }
+
+      &.error {
+        border-left-color: #ef4444;
+      }
+    }
+  }
+
+  .empty-state {
+    margin: 0;
+    padding: 24px 12px;
+    text-align: center;
+    color: #94a3b8;
+  }
+}

--- a/src/app/features/dashboard/components/temp-auth/temp-auth.component.scss
+++ b/src/app/features/dashboard/components/temp-auth/temp-auth.component.scss
@@ -1,226 +1,223 @@
 .temp-auth-page {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 16px;
   padding: 24px;
-  background: var(--page-background, #f5f5f5);
+  background: #f5f7fa;
+  min-height: 100%;
 
   .page-header {
-    background: #fff;
-    border-radius: 16px;
-    padding: 24px 28px;
-    box-shadow: 0 12px 32px -12px rgba(15, 23, 42, 0.18);
+    background: #ffffff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
 
     h1 {
-      margin: 0;
-      font-size: 1.8rem;
-      font-weight: 700;
-      color: #0f172a;
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      gap: 4px;
+      margin: 0 0 12px;
+      color: #0f172a;
+      font-weight: 700;
 
       span {
-        font-size: 0.9rem;
-        font-weight: 500;
+        font-size: 14px;
         color: #64748b;
+        font-weight: 400;
       }
     }
 
     p {
-      margin: 16px 0 0;
+      margin: 0;
       color: #475569;
-      line-height: 1.7;
+      line-height: 1.8;
     }
   }
 
-  nz-card {
-    border-radius: 16px;
-    box-shadow: 0 12px 32px -18px rgba(15, 23, 42, 0.25);
-  }
-
-  .config-card {
-    .config-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  .forms-row {
+    .auth-form {
+      display: flex;
+      flex-direction: column;
       gap: 16px;
 
       .form-field {
         display: flex;
         flex-direction: column;
-        gap: 8px;
+        gap: 6px;
 
-        .label-text {
+        .label {
+          font-size: 13px;
+          color: #475569;
           font-weight: 600;
-          color: #0f172a;
-        }
-
-        textarea[nz-input] {
-          resize: vertical;
         }
       }
 
-      .full-width {
-        grid-column: 1 / -1;
+      button {
+        align-self: flex-start;
       }
-    }
-
-    .action-row {
-      margin-top: 20px;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
     }
   }
 
-  .side-column {
+  .session-card {
     display: flex;
     flex-direction: column;
     gap: 16px;
-  }
 
-  .delete-card {
-    .card-helper {
-      margin-bottom: 12px;
-      color: #64748b;
-    }
-
-    .delete-grid {
-      display: grid;
-      grid-template-columns: 1fr auto;
+    .session-header {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
       gap: 12px;
 
-      @media (max-width: 768px) {
-        grid-template-columns: 1fr;
-      }
-    }
-  }
-
-  .devices-card {
-    .device-card {
-      border: 1px solid #e2e8f0;
-      border-radius: 12px;
-      padding: 16px;
-      margin-bottom: 12px;
-      background: #fff;
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-
-      &:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 14px 28px -18px rgba(15, 23, 42, 0.25);
-      }
-
-      .device-header {
+      .next-step {
         display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-        margin-bottom: 12px;
+        flex-direction: row;
+        align-items: baseline;
+        gap: 8px;
+        font-size: 14px;
 
-        h3 {
-          margin: 0;
-          font-size: 1.1rem;
+        .label {
+          color: #475569;
+        }
+
+        strong {
           color: #0f172a;
         }
       }
+    }
 
-      dl {
-        margin: 0;
+    .session-body {
+      background: #f8fafc;
+      border-radius: 8px;
+      padding: 16px;
+      font-size: 14px;
+      line-height: 1.8;
+
+      .session-info {
         display: grid;
+        gap: 4px;
+      }
+    }
+
+    .api-field {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+
+      span {
+        font-size: 12px;
+        color: #64748b;
+        font-weight: 600;
+      }
+    }
+
+    .session-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+
+      .device-controls {
+        display: flex;
+        flex-direction: row;
         gap: 8px;
+        flex-wrap: wrap;
 
-        div {
-          display: grid;
-          grid-template-columns: 140px 1fr;
-          gap: 12px;
-
-          dt {
-            margin: 0;
-            font-weight: 600;
-            color: #475569;
-          }
-
-          dd {
-            margin: 0;
-            color: #0f172a;
-            word-break: break-all;
-            direction: ltr;
-          }
+        input {
+          min-width: 220px;
         }
+      }
+
+      .success-message {
+        margin: 0;
+        color: #0f766e;
+        background: #ecfdf5;
+        border-radius: 8px;
+        padding: 12px;
+        font-size: 14px;
       }
     }
   }
 
   .log-card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
     .log-toolbar {
       display: flex;
       justify-content: flex-end;
-      margin-bottom: 12px;
     }
 
     .log-container {
-      max-height: 340px;
+      max-height: 360px;
       overflow-y: auto;
-      border: 1px solid #e2e8f0;
+      background: #0f172a;
       border-radius: 12px;
       padding: 16px;
-      background: #0f172a;
-    }
-
-    .log-entry {
-      background: rgba(15, 23, 42, 0.7);
-      border-radius: 12px;
-      padding: 12px 14px;
-      margin-bottom: 12px;
       color: #e2e8f0;
-      border-left: 3px solid transparent;
+      font-family: 'Fira Code', 'Courier New', monospace;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
 
-      &__header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin-bottom: 8px;
-        gap: 12px;
-
-        .timestamp {
-          font-family: 'Roboto Mono', monospace;
-          font-size: 0.85rem;
-          color: rgba(226, 232, 240, 0.7);
-        }
-      }
-
-      .message {
+      .empty-state {
         margin: 0;
-        font-weight: 600;
+        text-align: center;
+        color: #94a3b8;
       }
 
-      .detail {
-        margin: 8px 0 0;
-        font-size: 0.85rem;
-        line-height: 1.5;
-        color: rgba(226, 232, 240, 0.9);
-        white-space: pre-wrap;
-        direction: ltr;
-      }
+      .log-entry {
+        background: rgba(15, 23, 42, 0.6);
+        border-radius: 8px;
+        padding: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
 
-      &.info {
-        border-left-color: #38bdf8;
-      }
+        &.error {
+          border-color: rgba(239, 68, 68, 0.4);
+        }
 
-      &.success {
-        border-left-color: #22c55e;
-      }
+        &.success {
+          border-color: rgba(16, 185, 129, 0.4);
+        }
 
-      &.error {
-        border-left-color: #ef4444;
+        .log-entry__header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          font-size: 12px;
+          color: #cbd5f5;
+
+          .timestamp {
+            font-family: inherit;
+            letter-spacing: 0.5px;
+          }
+        }
+
+        .message {
+          margin: 0;
+          font-size: 14px;
+          color: #f8fafc;
+        }
+
+        .detail {
+          margin: 0;
+          white-space: pre-wrap;
+          word-break: break-word;
+          background: rgba(15, 23, 42, 0.5);
+          border-radius: 8px;
+          padding: 8px;
+          color: #cbd5f5;
+        }
       }
     }
   }
+}
 
-  .empty-state {
-    margin: 0;
-    padding: 24px 12px;
-    text-align: center;
-    color: #94a3b8;
+@media (max-width: 992px) {
+  .temp-auth-page {
+    padding: 16px;
   }
 }

--- a/src/app/features/dashboard/components/temp-auth/temp-auth.component.spec.ts
+++ b/src/app/features/dashboard/components/temp-auth/temp-auth.component.spec.ts
@@ -5,6 +5,18 @@ import { TempAuthComponent } from './temp-auth.component';
 describe('TempAuthComponent', () => {
   let component: TempAuthComponent;
   let fixture: ComponentFixture<TempAuthComponent>;
+  let originalFetch: typeof fetch | undefined;
+
+  beforeEach(() => {
+    originalFetch = (globalThis as any).fetch;
+    (globalThis as any).fetch = jasmine.createSpy('fetch').and.returnValue(
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('[]')
+      })
+    );
+  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -15,6 +27,10 @@ describe('TempAuthComponent', () => {
     fixture = TestBed.createComponent(TempAuthComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    (globalThis as any).fetch = originalFetch as any;
   });
 
   it('should create', () => {

--- a/src/app/features/dashboard/components/temp-auth/temp-auth.component.ts
+++ b/src/app/features/dashboard/components/temp-auth/temp-auth.component.ts
@@ -9,21 +9,33 @@ import { NzNotificationModule, NzNotificationService } from 'ng-zorro-antd/notif
 import { NzTagModule } from 'ng-zorro-antd/tag';
 import { NzTypographyModule } from 'ng-zorro-antd/typography';
 
-type LogLevel = 'info' | 'success' | 'error';
+export type LogLevel = 'info' | 'success' | 'error';
 
-interface LogEntry {
+export interface LogEntry {
   timestamp: string;
   level: LogLevel;
   message: string;
   detail?: string;
 }
 
-interface WebAuthnDevice {
-  credential_id: string;
-  sign_count: number;
-  device_name?: string;
-  created_at?: string;
-  last_used?: string;
+interface AuthState {
+  auth_stage: string;
+  webauthn_required: boolean;
+  webauthn_registered: boolean;
+  webauthn_completed: boolean;
+  next_step: string;
+}
+
+interface AuthResponse extends AuthState {
+  access_token: string;
+  token_type: string;
+}
+
+interface SessionResponse extends AuthState {
+  username: string;
+  email: string;
+  id: number;
+  created_at: string;
 }
 
 @Component({
@@ -41,319 +53,356 @@ interface WebAuthnDevice {
     NzTypographyModule,
   ],
   templateUrl: './temp-auth.component.html',
-  styleUrls: ['./temp-auth.component.scss']
+  styleUrls: ['./temp-auth.component.scss'],
 })
 export class TempAuthComponent implements OnInit {
   @ViewChild('logContainer') private logContainer?: ElementRef<HTMLDivElement>;
 
   apiBase = 'http://localhost:8001/api';
-  authToken = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwidXNlcm5hbWUiOiJtb2hhbW1hZCIsImF1dGhfc3RhZ2UiOiJwYXNzd29yZF92ZXJpZmllZCIsIndlYmF1dGhuX3JlcXVpcmVkIjp0cnVlLCJ3ZWJhdXRobl9jb21wbGV0ZWQiOmZhbHNlLCJleHAiOjE3NTg5MTAzNzJ9.uIehYsRMdzxf4rBqm9W6ddkfOknP3WpSJV-KDdbC1hk';
-  credentialId = '';
+
+  signUpForm = {
+    username: '',
+    email: '',
+    password: '',
+  };
+
+  signInForm = {
+    username: '',
+    password: '',
+  };
+
+  deviceName = '';
+
+  authToken?: string;
+  lastAuthResponse?: AuthResponse;
+  session?: SessionResponse;
 
   logs: LogEntry[] = [];
-  devices: WebAuthnDevice[] = [];
 
   loading = {
+    signUp: false,
+    signIn: false,
+    session: false,
     register: false,
     authenticate: false,
-    list: false,
-    delete: false,
-    getMe: false,
   };
 
   private readonly notification = inject(NzNotificationService);
 
+  private readonly nextStepDictionary: Record<string, string> = {
+    webauthn_register: 'ثبت دستگاه با WebAuthn',
+    webauthn_authenticate: 'احراز هویت با دستگاه',
+    authenticated: 'احراز هویت کامل شده است',
+  };
+
   ngOnInit(): void {
-    if (typeof window !== 'undefined') {
-      this.listDevices();
+    this.log('برای شروع، یکی از فرم‌های ثبت‌نام یا ورود را تکمیل کنید.');
+  }
+
+  get nextStepDescription(): string {
+    const step = this.state?.next_step;
+    if (!step) {
+      return 'مرحله بعدی مشخص نیست.';
+    }
+    return this.nextStepDictionary[step] ?? `مرحله بعد: ${step}`;
+  }
+
+  get requiresRegistration(): boolean {
+    const state = this.state;
+    return !!state && state.webauthn_required && !state.webauthn_registered;
+  }
+
+  get requiresAuthentication(): boolean {
+    const state = this.state;
+    return !!state && state.webauthn_required && state.webauthn_registered && !state.webauthn_completed;
+  }
+
+  get fullyAuthenticated(): boolean {
+    return !!this.state?.webauthn_completed;
+  }
+
+  async submitSignUp(): Promise<void> {
+    this.loading.signUp = true;
+    this.log('ارسال درخواست ثبت‌نام کاربر', this.signUpForm);
+    try {
+      const response = await this.fetchWithLogging(this.getApiUrl('/authentication/register'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(this.signUpForm),
+      });
+
+      if (!response.ok) {
+        await this.handleHttpError('ثبت‌نام با خطا مواجه شد', response);
+        return;
+      }
+
+      const data = await this.readJson<AuthResponse>(response);
+      await this.handleAuthSuccess(data, 'ثبت‌نام');
+      this.notification.success('ثبت‌نام موفق', 'حساب کاربری ایجاد شد.');
+    } catch (error) {
+      this.handleError('ثبت‌نام ناموفق بود', error);
+    } finally {
+      this.loading.signUp = false;
     }
   }
 
-  logColor(level: LogLevel): string {
-    switch (level) {
-      case 'success':
-        return 'green';
-      case 'error':
-        return 'red';
-      default:
-        return 'blue';
+  async submitSignIn(): Promise<void> {
+    this.loading.signIn = true;
+    this.log('ارسال درخواست ورود کاربر', this.signInForm);
+    try {
+      const body = new URLSearchParams({
+        username: this.signInForm.username,
+        password: this.signInForm.password,
+      });
+      const response = await this.fetchWithLogging(this.getApiUrl('/authentication/login'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: body.toString(),
+      });
+
+      if (!response.ok) {
+        await this.handleHttpError('ورود با خطا مواجه شد', response);
+        return;
+      }
+
+      const data = await this.readJson<AuthResponse>(response);
+      await this.handleAuthSuccess(data, 'ورود');
+      this.notification.success('ورود موفق', 'احراز هویت اولیه تکمیل شد.');
+    } catch (error) {
+      this.handleError('ورود ناموفق بود', error);
+    } finally {
+      this.loading.signIn = false;
     }
   }
 
-  async startRegistration(retrying = false): Promise<void> {
-    if (!('credentials' in navigator)) {
-      this.logError('WebAuthn API در دسترس نیست', new Error('navigator.credentials not available'));
-      this.notification.error('خطا', 'مرورگر شما از WebAuthn پشتیبانی نمی‌کند.');
+  async refreshSession(): Promise<void> {
+    if (!this.ensureToken()) {
+      return;
+    }
+
+    this.loading.session = true;
+    this.log('دریافت اطلاعات کاربر احراز هویت شده');
+    try {
+      const response = await this.fetchWithLogging(this.getApiUrl('/authentication/me'), {
+        headers: this.getAuthHeaders(),
+      });
+
+      if (!response.ok) {
+        await this.handleHttpError('دریافت اطلاعات کاربر با خطا مواجه شد', response);
+        return;
+      }
+
+      const data = await this.readJson<SessionResponse>(response);
+      this.session = data;
+      this.logSuccess('اطلاعات کاربر با موفقیت دریافت شد', data);
+    } catch (error) {
+      this.handleError('عدم موفقیت در دریافت اطلاعات کاربر', error);
+    } finally {
+      this.loading.session = false;
+    }
+  }
+
+  async registerDevice(): Promise<void> {
+    if (!this.ensureToken() || !this.ensureWebAuthnAvailable()) {
       return;
     }
 
     this.loading.register = true;
-    this.log('شروع فرآیند ثبت نام');
+    this.log('شروع فرآیند ثبت دستگاه WebAuthn');
     try {
-      const response = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/registration/start`, {
+      const startResponse = await this.fetchWithLogging(this.getApiUrl('/webauthn/registration/start'), {
         method: 'POST',
-        headers: this.getAuthHeaders(),
+        headers: this.getAuthHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({}),
       });
 
-      if (!response.ok) {
-        const body = await response.text();
-        this.logError('registration/start با خطا مواجه شد', new Error(body || response.statusText));
+      if (!startResponse.ok) {
+        await this.handleHttpError('شروع ثبت دستگاه با خطا مواجه شد', startResponse);
         return;
       }
 
-      const { publicKey } = await this.readJson<{ publicKey: any }>(response);
-      const excludedIds = (publicKey?.exclude_credentials ?? publicKey?.excludeCredentials ?? []).map((cred: any) => cred.id as string);
-
-      if (excludedIds.length) {
-        const cleared = await this.handleExcludedCredentials(excludedIds);
-        if (!cleared) {
-          return;
-        }
-
-        if (!retrying) {
-          this.log('تلاش مجدد برای ثبت‌نام پس از حذف اطلاعات قبلی');
-          await this.startRegistration(true);
-          return;
-        }
-      }
-
+      const { publicKey } = await this.readJson<{ publicKey: any }>(startResponse);
       const options = this.normaliseRegistrationOptions(publicKey);
-      this.log('در حال فراخوانی navigator.credentials.create', options);
       const credential = await navigator.credentials.create({ publicKey: options });
-      this.logSuccess('گواهی جدید ساخته شد', credential);
 
       if (!credential || credential.type !== 'public-key') {
-        this.logError('گواهی بازگشتی نامعتبر بود', new Error('Unsupported credential type'));
-        return;
+        throw new Error('گواهی بازگشتی برای ثبت دستگاه معتبر نبود');
       }
 
-      const publicKeyCredential = credential as PublicKeyCredential;
+      const payload = this.publicKeyCredentialToJSON(credential as PublicKeyCredential);
+      if (this.deviceName.trim()) {
+        payload['device_name'] = this.deviceName.trim();
+      }
 
-      const payload = {
-        id: publicKeyCredential.id,
-        rawId: this.bufferEncode(publicKeyCredential.rawId),
-        type: publicKeyCredential.type,
-        response: {
-          clientDataJSON: this.bufferEncode(publicKeyCredential.response.clientDataJSON),
-          attestationObject: this.bufferEncode((publicKeyCredential.response as AuthenticatorAttestationResponse).attestationObject),
-        },
-      };
-
-      this.log('ارسال اطلاعات تکمیل ثبت‌نام', payload);
-      const finish = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/registration/complete`, {
+      const finishResponse = await this.fetchWithLogging(this.getApiUrl('/webauthn/registration/complete'), {
         method: 'POST',
-        headers: this.getAuthHeaders(),
+        headers: this.getAuthHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(payload),
       });
 
-      const result = await this.readJson(finish);
-      if (!finish.ok) {
-        this.logError('registration/complete با خطا مواجه شد', new Error(JSON.stringify(result)));
+      if (!finishResponse.ok) {
+        await this.handleHttpError('تکمیل ثبت دستگاه با خطا مواجه شد', finishResponse);
         return;
       }
 
-      this.logSuccess('ثبت‌نام با موفقیت تکمیل شد', result);
-      this.notification.success('ثبت‌نام موفق', 'دستگاه با موفقیت ثبت شد.');
-      await this.listDevices();
+      const data = await this.readJson<AuthResponse>(finishResponse);
+      await this.handleAuthSuccess(data, 'ثبت دستگاه');
+      this.deviceName = '';
+      this.notification.success('ثبت دستگاه موفق', 'دستگاه شما با موفقیت ثبت شد.');
     } catch (error) {
-      if ((error as Error)?.name === 'InvalidStateError') {
-        this.logError('این دستگاه قبلاً ثبت شده است.', error as Error);
-        this.notification.warning('هشدار', 'این دستگاه قبلاً ثبت شده است. ابتدا آن را حذف کنید.');
-      } else if ((error as Error)?.name === 'NotAllowedError') {
-        this.logError('فرآیند ثبت‌نام لغو یا منقضی شد.', error as Error);
+      if ((error as Error)?.name === 'NotAllowedError') {
+        this.handleError('فرآیند ثبت دستگاه توسط کاربر لغو شد یا منقضی گردید.', error);
       } else {
-        this.logError('خطا در startRegistration', error as Error);
+        this.handleError('ثبت دستگاه با خطا روبرو شد', error);
       }
     } finally {
       this.loading.register = false;
     }
   }
 
-  async startAuthentication(): Promise<void> {
-    if (!('credentials' in navigator)) {
-      this.logError('WebAuthn API در دسترس نیست', new Error('navigator.credentials not available'));
-      this.notification.error('خطا', 'مرورگر شما از WebAuthn پشتیبانی نمی‌کند.');
+  async authenticateDevice(): Promise<void> {
+    if (!this.ensureToken() || !this.ensureWebAuthnAvailable()) {
       return;
     }
 
     this.loading.authenticate = true;
-    this.log('شروع فرآیند احراز هویت');
+    this.log('شروع فرآیند احراز هویت با WebAuthn');
     try {
-      const response = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/authentication/start`, {
+      const startResponse = await this.fetchWithLogging(this.getApiUrl('/webauthn/authentication/start'), {
         method: 'POST',
-        headers: this.getAuthHeaders(),
+        headers: this.getAuthHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({}),
       });
 
-      if (!response.ok) {
-        const body = await response.text();
-        this.logError('authentication/start با خطا مواجه شد', new Error(body || response.statusText));
+      if (!startResponse.ok) {
+        await this.handleHttpError('شروع احراز هویت دستگاه با خطا مواجه شد', startResponse);
         return;
       }
 
-      const { publicKey } = await this.readJson<{ publicKey: PublicKeyCredentialRequestOptions & Record<string, unknown> }>(response);
+      const { publicKey } = await this.readJson<{ publicKey: any }>(startResponse);
       const options = this.normaliseAuthenticationOptions(publicKey);
-      this.log('در حال فراخوانی navigator.credentials.get', options);
       const credential = await navigator.credentials.get({ publicKey: options });
-      this.logSuccess('داده احراز هویت دریافت شد', credential);
 
       if (!credential || credential.type !== 'public-key') {
-        this.logError('گواهی بازگشتی نامعتبر بود', new Error('Unsupported credential type'));
-        return;
+        throw new Error('گواهی بازگشتی برای احراز هویت معتبر نبود');
       }
 
-      const assertion = credential as PublicKeyCredential;
-      const authResponse = assertion.response as AuthenticatorAssertionResponse;
-
-      const payload = {
-        id: assertion.id,
-        rawId: this.bufferEncode(assertion.rawId),
-        type: assertion.type,
-        response: {
-          authenticatorData: this.bufferEncode(authResponse.authenticatorData),
-          clientDataJSON: this.bufferEncode(authResponse.clientDataJSON),
-          signature: this.bufferEncode(authResponse.signature),
-          userHandle: authResponse.userHandle ? this.bufferEncode(authResponse.userHandle) : null,
-        },
-      };
-
-      this.log('ارسال اطلاعات تکمیل احراز هویت', payload);
-      const finish = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/authentication/complete`, {
+      const payload = this.publicKeyAssertionToJSON(credential as PublicKeyCredential);
+      const finishResponse = await this.fetchWithLogging(this.getApiUrl('/webauthn/authentication/complete'), {
         method: 'POST',
-        headers: this.getAuthHeaders(),
+        headers: this.getAuthHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(payload),
       });
 
-      const result = await this.readJson(finish);
-      if (!finish.ok) {
-        this.logError('authentication/complete با خطا مواجه شد', new Error(JSON.stringify(result)));
+      if (!finishResponse.ok) {
+        await this.handleHttpError('تکمیل احراز هویت دستگاه با خطا مواجه شد', finishResponse);
         return;
       }
 
-      this.logSuccess('احراز هویت با موفقیت انجام شد', result);
-      this.notification.success('احراز هویت موفق', 'ورود با موفقیت انجام شد.');
+      const data = await this.readJson<AuthResponse>(finishResponse);
+      await this.handleAuthSuccess(data, 'احراز هویت با دستگاه');
+      this.notification.success('احراز هویت موفق', 'ورود شما تکمیل شد.');
     } catch (error) {
       if ((error as Error)?.name === 'NotAllowedError') {
-        this.logError('فرآیند احراز هویت لغو یا منقضی شد.', error as Error);
+        this.handleError('فرآیند احراز هویت دستگاه لغو شد یا منقضی گردید.', error);
       } else {
-        this.logError('خطا در startAuthentication', error as Error);
+        this.handleError('احراز هویت دستگاه با خطا روبرو شد', error);
       }
     } finally {
       this.loading.authenticate = false;
     }
   }
 
-  async listDevices(): Promise<void> {
-    this.loading.list = true;
-    this.log('دریافت فهرست دستگاه‌ها');
-    try {
-      const response = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/devices`, {
-        method: 'GET',
-        headers: this.getAuthHeaders(),
-      });
-
-      const result = await this.readJson<WebAuthnDevice[]>(response);
-      if (!response.ok) {
-        this.logError('دریافت دستگاه‌ها با خطا مواجه شد', new Error(JSON.stringify(result)));
-        return;
-      }
-
-      this.devices = Array.isArray(result) ? result : [];
-      this.logSuccess('دستگاه‌ها با موفقیت دریافت شدند', result);
-    } catch (error) {
-      this.logError('خطا در listDevices', error as Error);
-    } finally {
-      this.loading.list = false;
-    }
-  }
-
-  async deleteDevice(): Promise<void> {
-    if (!this.credentialId.trim()) {
-      this.logError('شناسه اعتبارنامه الزامی است', new Error('Credential id is required'));
-      this.notification.warning('هشدار', 'لطفاً شناسه اعتبارنامه را وارد کنید.');
-      return;
-    }
-
-    this.loading.delete = true;
-    this.log('حذف دستگاه با شناسه وارد شده');
-    try {
-      const deleted = await this.deleteCredentialById(this.credentialId.trim());
-      if (!deleted) {
-        return;
-      }
-
-      this.notification.success('حذف موفق', 'دستگاه با موفقیت حذف شد.');
-      this.credentialId = '';
-      await this.listDevices();
-    } catch (error) {
-      this.logError('خطا در deleteDevice', error as Error);
-    } finally {
-      this.loading.delete = false;
-    }
-  }
-
-  async getMe(): Promise<void> {
-    this.loading.getMe = true;
-    this.log('دریافت اطلاعات کاربر جاری');
-    try {
-      const response = await this.fetchWithLogging(`${this.getApiBase()}/authentication/me`, {
-        method: 'GET',
-        headers: this.getAuthHeaders(),
-      });
-
-      const result = await this.readJson(response);
-      if (!response.ok) {
-        this.logError('دریافت اطلاعات کاربر با خطا مواجه شد', new Error(JSON.stringify(result)));
-        return;
-      }
-
-      this.logSuccess('اطلاعات کاربر دریافت شد', result);
-      this.notification.info('اطلاعات کاربر', JSON.stringify(result, null, 2));
-    } catch (error) {
-      this.logError('خطا در getMe', error as Error);
-    } finally {
-      this.loading.getMe = false;
-    }
-  }
-
-  clearLog(): void {
-    this.log('پاکسازی گزارش‌ها فراخوانی شد');
+  clearLogs(): void {
     this.logs = [];
-    this.notification.info('گزارش‌ها پاک شدند', 'تاریخچه وقایع حذف شد.');
   }
 
-  private getApiBase(): string {
-    return this.apiBase.trim().replace(/\/$/, '');
+  get state(): AuthState | undefined {
+    return this.session ?? this.lastAuthResponse;
   }
 
-  private getAuthHeaders(): HeadersInit {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
+  private async handleAuthSuccess(response: AuthResponse, context: string): Promise<void> {
+    this.setToken(response);
+    this.lastAuthResponse = response;
+    this.logSuccess(`${context} با موفقیت انجام شد`, response);
+    await this.refreshSession();
+  }
 
-    const token = this.authToken.trim();
-    if (token) {
-      headers['Authorization'] = token;
+  private setToken(response: AuthResponse): void {
+    const tokenType = response.token_type || 'Bearer';
+    this.authToken = `${tokenType} ${response.access_token}`;
+  }
+
+  private ensureToken(): boolean {
+    if (!this.authToken) {
+      this.notification.warning('نیاز به ورود', 'ابتدا وارد حساب خود شوید.');
+      this.logError('هیچ توکن احراز هویتی در دسترس نیست');
+      return false;
     }
-
-    this.log('هدرهای احراز هویت آماده شد', headers);
-    return headers;
+    return true;
   }
 
-  private timestamp(): string {
-    return new Date().toISOString().replace('T', ' ').replace('Z', '');
+  private ensureWebAuthnAvailable(): boolean {
+    if (!('credentials' in navigator)) {
+      this.notification.error('خطا', 'مرورگر شما از WebAuthn پشتیبانی نمی‌کند.');
+      this.logError('WebAuthn API در دسترس نیست');
+      return false;
+    }
+    return true;
+  }
+
+  private async handleHttpError(message: string, response: Response): Promise<void> {
+    const detail = await response.text();
+    const error = new Error(detail || response.statusText);
+    this.handleError(message, error);
+  }
+
+  private handleError(message: string, error: unknown): void {
+    const err = error instanceof Error ? error : new Error(String(error));
+    this.logError(message, err);
+    this.notification.error('خطا', err.message);
+  }
+
+  private getApiUrl(path: string): string {
+    const base = this.apiBase.replace(/\/?$/, '');
+    const suffix = path.startsWith('/') ? path : `/${path}`;
+    return `${base}${suffix}`;
+  }
+
+  private getAuthHeaders(extra: HeadersInit = {}): HeadersInit {
+    return {
+      Authorization: this.authToken ?? '',
+      ...extra,
+    };
+  }
+
+  private async fetchWithLogging(url: string, options?: RequestInit): Promise<Response> {
+    this.log(`HTTP ${options?.method || 'GET'} ${url}`, options?.body);
+    const response = await fetch(url, options);
+    this.logSuccess(`HTTP ${response.status} ${url}`);
+    return response;
+  }
+
+  private async readJson<T>(response: Response): Promise<T> {
+    const text = await response.text();
+    if (!text) {
+      return {} as T;
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch (error) {
+      this.logError('تجزیه JSON با خطا مواجه شد', error as Error);
+      throw error;
+    }
   }
 
   private log(message: string, meta?: unknown, level: LogLevel = 'info'): void {
-    if (meta instanceof Error) {
-      console.error(`[${this.timestamp()}]`, message, meta);
-    } else {
-      console.log(`[${this.timestamp()}]`, message, meta ?? '');
-    }
-
     const entry: LogEntry = {
-      timestamp: this.timestamp(),
+      timestamp: new Date().toLocaleTimeString('fa-IR', { hour12: false }),
       level,
       message,
       detail: this.formatMeta(meta),
@@ -363,41 +412,36 @@ export class TempAuthComponent implements OnInit {
     this.scheduleLogScroll();
   }
 
-  private logError(message: string, error?: unknown): void {
-    this.log(message, error, 'error');
+  private logSuccess(message: string, meta?: unknown): void {
+    this.log(message, meta, 'success');
   }
 
-  private logSuccess(message: string, data?: unknown): void {
-    this.log(message, data, 'success');
+  private logError(message: string, meta?: unknown): void {
+    this.log(message, meta, 'error');
   }
 
   private scheduleLogScroll(): void {
-    const scheduler = typeof queueMicrotask === 'function'
-      ? queueMicrotask
-      : (cb: () => void) => Promise.resolve().then(cb);
-    scheduler(() => this.scrollLogToBottom());
+    const scheduler = typeof queueMicrotask === 'function' ? queueMicrotask : (cb: () => void) => Promise.resolve().then(cb);
+    scheduler(() => this.scrollLogsToBottom());
   }
 
-  private scrollLogToBottom(): void {
+  private scrollLogsToBottom(): void {
     const element = this.logContainer?.nativeElement;
     if (element) {
       element.scrollTop = element.scrollHeight;
     }
   }
 
-  private formatMeta(meta?: unknown): string | undefined {
+  private formatMeta(meta: unknown): string | undefined {
     if (meta instanceof Error) {
       return `${meta.name}: ${meta.message}`;
     }
-
     if (meta === undefined || meta === null || meta === '') {
       return undefined;
     }
-
     if (typeof meta === 'string') {
       return meta;
     }
-
     try {
       return JSON.stringify(meta, null, 2);
     } catch {
@@ -405,97 +449,8 @@ export class TempAuthComponent implements OnInit {
     }
   }
 
-  private async fetchWithLogging(url: string, options?: RequestInit): Promise<Response> {
-    let bodyForLog: unknown;
-    if (options?.body && typeof options.body === 'string') {
-      try {
-        bodyForLog = JSON.parse(options.body);
-      } catch {
-        bodyForLog = '(body not JSON)';
-      }
-    } else if (options?.body) {
-      bodyForLog = options.body;
-    }
-
-    this.log(`HTTP ${options?.method || 'GET'} ${url}`, bodyForLog);
-    const response = await fetch(url, options);
-    this.logSuccess(`HTTP ${response.status} ${url}`);
-    return response;
-  }
-
-  private async deleteCredentialById(credentialId: string): Promise<boolean> {
-    const response = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/devices/${encodeURIComponent(credentialId)}`, {
-      method: 'DELETE',
-      headers: this.getAuthHeaders(),
-    });
-
-    if (!response.ok) {
-      const body = await response.text();
-      this.logError('حذف دستگاه با خطا مواجه شد', new Error(body || response.statusText));
-      return false;
-    }
-
-    this.logSuccess('دستگاه حذف شد', credentialId);
-    return true;
-  }
-
-  private async handleExcludedCredentials(encodedIds: string[]): Promise<boolean> {
-    if (!encodedIds.length) {
-      return true;
-    }
-
-    this.logError('این دستگاه از قبل ثبت شده است', { encodedIds });
-    const confirmed = window.confirm(
-      `این دستگاه قبلاً ${encodedIds.length} اعتبارنامه ثبت شده دارد.\n` +
-      `مرورگر کروم از ثبت دوباره جلوگیری می‌کند تا زمانی که آن‌ها را حذف کنید.\n\n` +
-      `برای حذف خودکار و تلاش مجدد روی OK کلیک کنید.`
-    );
-
-    if (!confirmed) {
-      this.log('فرآیند ثبت‌نام توسط کاربر لغو شد.');
-      return false;
-    }
-
-    for (const credentialId of encodedIds) {
-      const deleted = await this.deleteCredentialById(credentialId);
-      if (!deleted) {
-        this.logError('حذف خودکار اعتبارنامه با خطا مواجه شد', new Error(credentialId));
-        return false;
-      }
-    }
-
-    await this.listDevices();
-    this.logSuccess('اعتبارنامه‌های قبلی حذف شدند. لطفاً دوباره تلاش کنید.');
-    return true;
-  }
-
-  private async readJson<T = any>(response: Response): Promise<T> {
-    const text = await response.text();
-    if (!text) {
-      return {} as T;
-    }
-
-    try {
-      return JSON.parse(text) as T;
-    } catch (error) {
-      this.logError('تجزیه JSON با خطا مواجه شد', error as Error);
-      throw error;
-    }
-  }
-
-  private convertProperty(object: Record<string, any>, from: string, to: string): void {
-    if (object && Object.hasOwn(object, from)) {
-      object[to] = object[from];
-      delete object[from];
-    }
-  }
-
   private normaliseRegistrationOptions(publicKey: any): PublicKeyCredentialCreationOptions {
-    this.log('نرمال‌سازی گزینه‌های ثبت‌نام', publicKey);
-    const copy: any = typeof structuredClone === 'function'
-      ? structuredClone(publicKey)
-      : JSON.parse(JSON.stringify(publicKey));
-
+    const copy: any = typeof structuredClone === 'function' ? structuredClone(publicKey) : JSON.parse(JSON.stringify(publicKey));
     copy.challenge = this.bufferDecode(copy.challenge);
     if (copy.user?.id) {
       copy.user.id = this.bufferDecode(copy.user.id);
@@ -520,24 +475,18 @@ export class TempAuthComponent implements OnInit {
       this.convertProperty(copy.user, 'display_name', 'displayName');
     }
 
-    this.logSuccess('گزینه‌های ثبت‌نام آماده شد', copy);
     return copy as PublicKeyCredentialCreationOptions;
   }
 
   private normaliseAuthenticationOptions(publicKey: any): PublicKeyCredentialRequestOptions {
-    this.log('نرمال‌سازی گزینه‌های احراز هویت', publicKey);
-    const copy: any = typeof structuredClone === 'function'
-      ? structuredClone(publicKey)
-      : JSON.parse(JSON.stringify(publicKey));
-
+    const copy: any = typeof structuredClone === 'function' ? structuredClone(publicKey) : JSON.parse(JSON.stringify(publicKey));
     copy.challenge = this.bufferDecode(copy.challenge);
 
-    const allowCredentials = (copy.allow_credentials ?? copy.allowCredentials ?? []).map((cred: any) => ({
+    const allow = (copy.allow_credentials ?? copy.allowCredentials ?? []).map((cred: any) => ({
       ...cred,
       id: this.toBufferSource(cred.id),
     }));
-
-    copy.allowCredentials = allowCredentials;
+    copy.allowCredentials = allow;
     delete copy.allow_credentials;
 
     if (copy.authenticator_selection) {
@@ -550,8 +499,42 @@ export class TempAuthComponent implements OnInit {
       this.convertProperty(copy.authenticatorSelection, 'require_resident_key', 'requireResidentKey');
     }
 
-    this.logSuccess('گزینه‌های احراز هویت آماده شد', copy);
     return copy as PublicKeyCredentialRequestOptions;
+  }
+
+  private publicKeyCredentialToJSON(credential: PublicKeyCredential): Record<string, unknown> {
+    const attestation = credential.response as AuthenticatorAttestationResponse;
+    return {
+      id: credential.id,
+      rawId: this.bufferEncode(credential.rawId),
+      type: credential.type,
+      response: {
+        clientDataJSON: this.bufferEncode(attestation.clientDataJSON),
+        attestationObject: this.bufferEncode(attestation.attestationObject),
+      },
+    };
+  }
+
+  private publicKeyAssertionToJSON(credential: PublicKeyCredential): Record<string, unknown> {
+    const assertion = credential.response as AuthenticatorAssertionResponse;
+    return {
+      id: credential.id,
+      rawId: this.bufferEncode(credential.rawId),
+      type: credential.type,
+      response: {
+        clientDataJSON: this.bufferEncode(assertion.clientDataJSON),
+        authenticatorData: this.bufferEncode(assertion.authenticatorData),
+        signature: this.bufferEncode(assertion.signature),
+        userHandle: assertion.userHandle ? this.bufferEncode(assertion.userHandle) : null,
+      },
+    };
+  }
+
+  private convertProperty(object: Record<string, any>, from: string, to: string): void {
+    if (object && Object.hasOwn(object, from)) {
+      object[to] = object[from];
+      delete object[from];
+    }
   }
 
   private bufferDecode(value: string): Uint8Array {
@@ -571,15 +554,12 @@ export class TempAuthComponent implements OnInit {
     if (!value) {
       return null;
     }
-
     if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
-      return value as ArrayBuffer | ArrayBufferView;
+      return value;
     }
-
     if (typeof value === 'string') {
       return this.bufferDecode(value);
     }
-
     throw new TypeError('Unsupported credential buffer value');
   }
 }

--- a/src/app/features/dashboard/components/temp-auth/temp-auth.component.ts
+++ b/src/app/features/dashboard/components/temp-auth/temp-auth.component.ts
@@ -1,11 +1,585 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef, OnInit, ViewChild, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzCardModule } from 'ng-zorro-antd/card';
+import { NzGridModule } from 'ng-zorro-antd/grid';
+import { NzInputModule } from 'ng-zorro-antd/input';
+import { NzNotificationModule, NzNotificationService } from 'ng-zorro-antd/notification';
+import { NzTagModule } from 'ng-zorro-antd/tag';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+
+type LogLevel = 'info' | 'success' | 'error';
+
+interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  detail?: string;
+}
+
+interface WebAuthnDevice {
+  credential_id: string;
+  sign_count: number;
+  device_name?: string;
+  created_at?: string;
+  last_used?: string;
+}
 
 @Component({
   selector: 'app-temp-auth',
-  imports: [],
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    NzButtonModule,
+    NzCardModule,
+    NzGridModule,
+    NzInputModule,
+    NzNotificationModule,
+    NzTagModule,
+    NzTypographyModule,
+  ],
   templateUrl: './temp-auth.component.html',
-  styleUrl: './temp-auth.component.scss'
+  styleUrls: ['./temp-auth.component.scss']
 })
-export class TempAuthComponent {
+export class TempAuthComponent implements OnInit {
+  @ViewChild('logContainer') private logContainer?: ElementRef<HTMLDivElement>;
 
+  apiBase = 'http://localhost:8001/api';
+  authToken = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwidXNlcm5hbWUiOiJtb2hhbW1hZCIsImF1dGhfc3RhZ2UiOiJwYXNzd29yZF92ZXJpZmllZCIsIndlYmF1dGhuX3JlcXVpcmVkIjp0cnVlLCJ3ZWJhdXRobl9jb21wbGV0ZWQiOmZhbHNlLCJleHAiOjE3NTg5MTAzNzJ9.uIehYsRMdzxf4rBqm9W6ddkfOknP3WpSJV-KDdbC1hk';
+  credentialId = '';
+
+  logs: LogEntry[] = [];
+  devices: WebAuthnDevice[] = [];
+
+  loading = {
+    register: false,
+    authenticate: false,
+    list: false,
+    delete: false,
+    getMe: false,
+  };
+
+  private readonly notification = inject(NzNotificationService);
+
+  ngOnInit(): void {
+    if (typeof window !== 'undefined') {
+      this.listDevices();
+    }
+  }
+
+  logColor(level: LogLevel): string {
+    switch (level) {
+      case 'success':
+        return 'green';
+      case 'error':
+        return 'red';
+      default:
+        return 'blue';
+    }
+  }
+
+  async startRegistration(retrying = false): Promise<void> {
+    if (!('credentials' in navigator)) {
+      this.logError('WebAuthn API در دسترس نیست', new Error('navigator.credentials not available'));
+      this.notification.error('خطا', 'مرورگر شما از WebAuthn پشتیبانی نمی‌کند.');
+      return;
+    }
+
+    this.loading.register = true;
+    this.log('شروع فرآیند ثبت نام');
+    try {
+      const response = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/registration/start`, {
+        method: 'POST',
+        headers: this.getAuthHeaders(),
+        body: JSON.stringify({}),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        this.logError('registration/start با خطا مواجه شد', new Error(body || response.statusText));
+        return;
+      }
+
+      const { publicKey } = await this.readJson<{ publicKey: any }>(response);
+      const excludedIds = (publicKey?.exclude_credentials ?? publicKey?.excludeCredentials ?? []).map((cred: any) => cred.id as string);
+
+      if (excludedIds.length) {
+        const cleared = await this.handleExcludedCredentials(excludedIds);
+        if (!cleared) {
+          return;
+        }
+
+        if (!retrying) {
+          this.log('تلاش مجدد برای ثبت‌نام پس از حذف اطلاعات قبلی');
+          await this.startRegistration(true);
+          return;
+        }
+      }
+
+      const options = this.normaliseRegistrationOptions(publicKey);
+      this.log('در حال فراخوانی navigator.credentials.create', options);
+      const credential = await navigator.credentials.create({ publicKey: options });
+      this.logSuccess('گواهی جدید ساخته شد', credential);
+
+      if (!credential || credential.type !== 'public-key') {
+        this.logError('گواهی بازگشتی نامعتبر بود', new Error('Unsupported credential type'));
+        return;
+      }
+
+      const publicKeyCredential = credential as PublicKeyCredential;
+
+      const payload = {
+        id: publicKeyCredential.id,
+        rawId: this.bufferEncode(publicKeyCredential.rawId),
+        type: publicKeyCredential.type,
+        response: {
+          clientDataJSON: this.bufferEncode(publicKeyCredential.response.clientDataJSON),
+          attestationObject: this.bufferEncode((publicKeyCredential.response as AuthenticatorAttestationResponse).attestationObject),
+        },
+      };
+
+      this.log('ارسال اطلاعات تکمیل ثبت‌نام', payload);
+      const finish = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/registration/complete`, {
+        method: 'POST',
+        headers: this.getAuthHeaders(),
+        body: JSON.stringify(payload),
+      });
+
+      const result = await this.readJson(finish);
+      if (!finish.ok) {
+        this.logError('registration/complete با خطا مواجه شد', new Error(JSON.stringify(result)));
+        return;
+      }
+
+      this.logSuccess('ثبت‌نام با موفقیت تکمیل شد', result);
+      this.notification.success('ثبت‌نام موفق', 'دستگاه با موفقیت ثبت شد.');
+      await this.listDevices();
+    } catch (error) {
+      if ((error as Error)?.name === 'InvalidStateError') {
+        this.logError('این دستگاه قبلاً ثبت شده است.', error as Error);
+        this.notification.warning('هشدار', 'این دستگاه قبلاً ثبت شده است. ابتدا آن را حذف کنید.');
+      } else if ((error as Error)?.name === 'NotAllowedError') {
+        this.logError('فرآیند ثبت‌نام لغو یا منقضی شد.', error as Error);
+      } else {
+        this.logError('خطا در startRegistration', error as Error);
+      }
+    } finally {
+      this.loading.register = false;
+    }
+  }
+
+  async startAuthentication(): Promise<void> {
+    if (!('credentials' in navigator)) {
+      this.logError('WebAuthn API در دسترس نیست', new Error('navigator.credentials not available'));
+      this.notification.error('خطا', 'مرورگر شما از WebAuthn پشتیبانی نمی‌کند.');
+      return;
+    }
+
+    this.loading.authenticate = true;
+    this.log('شروع فرآیند احراز هویت');
+    try {
+      const response = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/authentication/start`, {
+        method: 'POST',
+        headers: this.getAuthHeaders(),
+        body: JSON.stringify({}),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        this.logError('authentication/start با خطا مواجه شد', new Error(body || response.statusText));
+        return;
+      }
+
+      const { publicKey } = await this.readJson<{ publicKey: PublicKeyCredentialRequestOptions & Record<string, unknown> }>(response);
+      const options = this.normaliseAuthenticationOptions(publicKey);
+      this.log('در حال فراخوانی navigator.credentials.get', options);
+      const credential = await navigator.credentials.get({ publicKey: options });
+      this.logSuccess('داده احراز هویت دریافت شد', credential);
+
+      if (!credential || credential.type !== 'public-key') {
+        this.logError('گواهی بازگشتی نامعتبر بود', new Error('Unsupported credential type'));
+        return;
+      }
+
+      const assertion = credential as PublicKeyCredential;
+      const authResponse = assertion.response as AuthenticatorAssertionResponse;
+
+      const payload = {
+        id: assertion.id,
+        rawId: this.bufferEncode(assertion.rawId),
+        type: assertion.type,
+        response: {
+          authenticatorData: this.bufferEncode(authResponse.authenticatorData),
+          clientDataJSON: this.bufferEncode(authResponse.clientDataJSON),
+          signature: this.bufferEncode(authResponse.signature),
+          userHandle: authResponse.userHandle ? this.bufferEncode(authResponse.userHandle) : null,
+        },
+      };
+
+      this.log('ارسال اطلاعات تکمیل احراز هویت', payload);
+      const finish = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/authentication/complete`, {
+        method: 'POST',
+        headers: this.getAuthHeaders(),
+        body: JSON.stringify(payload),
+      });
+
+      const result = await this.readJson(finish);
+      if (!finish.ok) {
+        this.logError('authentication/complete با خطا مواجه شد', new Error(JSON.stringify(result)));
+        return;
+      }
+
+      this.logSuccess('احراز هویت با موفقیت انجام شد', result);
+      this.notification.success('احراز هویت موفق', 'ورود با موفقیت انجام شد.');
+    } catch (error) {
+      if ((error as Error)?.name === 'NotAllowedError') {
+        this.logError('فرآیند احراز هویت لغو یا منقضی شد.', error as Error);
+      } else {
+        this.logError('خطا در startAuthentication', error as Error);
+      }
+    } finally {
+      this.loading.authenticate = false;
+    }
+  }
+
+  async listDevices(): Promise<void> {
+    this.loading.list = true;
+    this.log('دریافت فهرست دستگاه‌ها');
+    try {
+      const response = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/devices`, {
+        method: 'GET',
+        headers: this.getAuthHeaders(),
+      });
+
+      const result = await this.readJson<WebAuthnDevice[]>(response);
+      if (!response.ok) {
+        this.logError('دریافت دستگاه‌ها با خطا مواجه شد', new Error(JSON.stringify(result)));
+        return;
+      }
+
+      this.devices = Array.isArray(result) ? result : [];
+      this.logSuccess('دستگاه‌ها با موفقیت دریافت شدند', result);
+    } catch (error) {
+      this.logError('خطا در listDevices', error as Error);
+    } finally {
+      this.loading.list = false;
+    }
+  }
+
+  async deleteDevice(): Promise<void> {
+    if (!this.credentialId.trim()) {
+      this.logError('شناسه اعتبارنامه الزامی است', new Error('Credential id is required'));
+      this.notification.warning('هشدار', 'لطفاً شناسه اعتبارنامه را وارد کنید.');
+      return;
+    }
+
+    this.loading.delete = true;
+    this.log('حذف دستگاه با شناسه وارد شده');
+    try {
+      const deleted = await this.deleteCredentialById(this.credentialId.trim());
+      if (!deleted) {
+        return;
+      }
+
+      this.notification.success('حذف موفق', 'دستگاه با موفقیت حذف شد.');
+      this.credentialId = '';
+      await this.listDevices();
+    } catch (error) {
+      this.logError('خطا در deleteDevice', error as Error);
+    } finally {
+      this.loading.delete = false;
+    }
+  }
+
+  async getMe(): Promise<void> {
+    this.loading.getMe = true;
+    this.log('دریافت اطلاعات کاربر جاری');
+    try {
+      const response = await this.fetchWithLogging(`${this.getApiBase()}/authentication/me`, {
+        method: 'GET',
+        headers: this.getAuthHeaders(),
+      });
+
+      const result = await this.readJson(response);
+      if (!response.ok) {
+        this.logError('دریافت اطلاعات کاربر با خطا مواجه شد', new Error(JSON.stringify(result)));
+        return;
+      }
+
+      this.logSuccess('اطلاعات کاربر دریافت شد', result);
+      this.notification.info('اطلاعات کاربر', JSON.stringify(result, null, 2));
+    } catch (error) {
+      this.logError('خطا در getMe', error as Error);
+    } finally {
+      this.loading.getMe = false;
+    }
+  }
+
+  clearLog(): void {
+    this.log('پاکسازی گزارش‌ها فراخوانی شد');
+    this.logs = [];
+    this.notification.info('گزارش‌ها پاک شدند', 'تاریخچه وقایع حذف شد.');
+  }
+
+  private getApiBase(): string {
+    return this.apiBase.trim().replace(/\/$/, '');
+  }
+
+  private getAuthHeaders(): HeadersInit {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    const token = this.authToken.trim();
+    if (token) {
+      headers['Authorization'] = token;
+    }
+
+    this.log('هدرهای احراز هویت آماده شد', headers);
+    return headers;
+  }
+
+  private timestamp(): string {
+    return new Date().toISOString().replace('T', ' ').replace('Z', '');
+  }
+
+  private log(message: string, meta?: unknown, level: LogLevel = 'info'): void {
+    if (meta instanceof Error) {
+      console.error(`[${this.timestamp()}]`, message, meta);
+    } else {
+      console.log(`[${this.timestamp()}]`, message, meta ?? '');
+    }
+
+    const entry: LogEntry = {
+      timestamp: this.timestamp(),
+      level,
+      message,
+      detail: this.formatMeta(meta),
+    };
+
+    this.logs = [...this.logs, entry];
+    this.scheduleLogScroll();
+  }
+
+  private logError(message: string, error?: unknown): void {
+    this.log(message, error, 'error');
+  }
+
+  private logSuccess(message: string, data?: unknown): void {
+    this.log(message, data, 'success');
+  }
+
+  private scheduleLogScroll(): void {
+    const scheduler = typeof queueMicrotask === 'function'
+      ? queueMicrotask
+      : (cb: () => void) => Promise.resolve().then(cb);
+    scheduler(() => this.scrollLogToBottom());
+  }
+
+  private scrollLogToBottom(): void {
+    const element = this.logContainer?.nativeElement;
+    if (element) {
+      element.scrollTop = element.scrollHeight;
+    }
+  }
+
+  private formatMeta(meta?: unknown): string | undefined {
+    if (meta instanceof Error) {
+      return `${meta.name}: ${meta.message}`;
+    }
+
+    if (meta === undefined || meta === null || meta === '') {
+      return undefined;
+    }
+
+    if (typeof meta === 'string') {
+      return meta;
+    }
+
+    try {
+      return JSON.stringify(meta, null, 2);
+    } catch {
+      return '(unserializable data)';
+    }
+  }
+
+  private async fetchWithLogging(url: string, options?: RequestInit): Promise<Response> {
+    let bodyForLog: unknown;
+    if (options?.body && typeof options.body === 'string') {
+      try {
+        bodyForLog = JSON.parse(options.body);
+      } catch {
+        bodyForLog = '(body not JSON)';
+      }
+    } else if (options?.body) {
+      bodyForLog = options.body;
+    }
+
+    this.log(`HTTP ${options?.method || 'GET'} ${url}`, bodyForLog);
+    const response = await fetch(url, options);
+    this.logSuccess(`HTTP ${response.status} ${url}`);
+    return response;
+  }
+
+  private async deleteCredentialById(credentialId: string): Promise<boolean> {
+    const response = await this.fetchWithLogging(`${this.getApiBase()}/webauthn/devices/${encodeURIComponent(credentialId)}`, {
+      method: 'DELETE',
+      headers: this.getAuthHeaders(),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      this.logError('حذف دستگاه با خطا مواجه شد', new Error(body || response.statusText));
+      return false;
+    }
+
+    this.logSuccess('دستگاه حذف شد', credentialId);
+    return true;
+  }
+
+  private async handleExcludedCredentials(encodedIds: string[]): Promise<boolean> {
+    if (!encodedIds.length) {
+      return true;
+    }
+
+    this.logError('این دستگاه از قبل ثبت شده است', { encodedIds });
+    const confirmed = window.confirm(
+      `این دستگاه قبلاً ${encodedIds.length} اعتبارنامه ثبت شده دارد.\n` +
+      `مرورگر کروم از ثبت دوباره جلوگیری می‌کند تا زمانی که آن‌ها را حذف کنید.\n\n` +
+      `برای حذف خودکار و تلاش مجدد روی OK کلیک کنید.`
+    );
+
+    if (!confirmed) {
+      this.log('فرآیند ثبت‌نام توسط کاربر لغو شد.');
+      return false;
+    }
+
+    for (const credentialId of encodedIds) {
+      const deleted = await this.deleteCredentialById(credentialId);
+      if (!deleted) {
+        this.logError('حذف خودکار اعتبارنامه با خطا مواجه شد', new Error(credentialId));
+        return false;
+      }
+    }
+
+    await this.listDevices();
+    this.logSuccess('اعتبارنامه‌های قبلی حذف شدند. لطفاً دوباره تلاش کنید.');
+    return true;
+  }
+
+  private async readJson<T = any>(response: Response): Promise<T> {
+    const text = await response.text();
+    if (!text) {
+      return {} as T;
+    }
+
+    try {
+      return JSON.parse(text) as T;
+    } catch (error) {
+      this.logError('تجزیه JSON با خطا مواجه شد', error as Error);
+      throw error;
+    }
+  }
+
+  private convertProperty(object: Record<string, any>, from: string, to: string): void {
+    if (object && Object.hasOwn(object, from)) {
+      object[to] = object[from];
+      delete object[from];
+    }
+  }
+
+  private normaliseRegistrationOptions(publicKey: any): PublicKeyCredentialCreationOptions {
+    this.log('نرمال‌سازی گزینه‌های ثبت‌نام', publicKey);
+    const copy: any = typeof structuredClone === 'function'
+      ? structuredClone(publicKey)
+      : JSON.parse(JSON.stringify(publicKey));
+
+    copy.challenge = this.bufferDecode(copy.challenge);
+    if (copy.user?.id) {
+      copy.user.id = this.bufferDecode(copy.user.id);
+    }
+
+    const exclude = copy.exclude_credentials ?? copy.excludeCredentials ?? [];
+    exclude.forEach((cred: any) => {
+      cred.id = this.bufferDecode(cred.id);
+    });
+
+    this.convertProperty(copy, 'pub_key_cred_params', 'pubKeyCredParams');
+    this.convertProperty(copy, 'authenticator_selection', 'authenticatorSelection');
+    this.convertProperty(copy, 'exclude_credentials', 'excludeCredentials');
+
+    if (copy.authenticatorSelection) {
+      this.convertProperty(copy.authenticatorSelection, 'user_verification', 'userVerification');
+      this.convertProperty(copy.authenticatorSelection, 'resident_key', 'residentKey');
+      this.convertProperty(copy.authenticatorSelection, 'require_resident_key', 'requireResidentKey');
+    }
+
+    if (copy.user) {
+      this.convertProperty(copy.user, 'display_name', 'displayName');
+    }
+
+    this.logSuccess('گزینه‌های ثبت‌نام آماده شد', copy);
+    return copy as PublicKeyCredentialCreationOptions;
+  }
+
+  private normaliseAuthenticationOptions(publicKey: any): PublicKeyCredentialRequestOptions {
+    this.log('نرمال‌سازی گزینه‌های احراز هویت', publicKey);
+    const copy: any = typeof structuredClone === 'function'
+      ? structuredClone(publicKey)
+      : JSON.parse(JSON.stringify(publicKey));
+
+    copy.challenge = this.bufferDecode(copy.challenge);
+
+    const allowCredentials = (copy.allow_credentials ?? copy.allowCredentials ?? []).map((cred: any) => ({
+      ...cred,
+      id: this.toBufferSource(cred.id),
+    }));
+
+    copy.allowCredentials = allowCredentials;
+    delete copy.allow_credentials;
+
+    if (copy.authenticator_selection) {
+      this.convertProperty(copy, 'authenticator_selection', 'authenticatorSelection');
+    }
+
+    if (copy.authenticatorSelection) {
+      this.convertProperty(copy.authenticatorSelection, 'user_verification', 'userVerification');
+      this.convertProperty(copy.authenticatorSelection, 'resident_key', 'residentKey');
+      this.convertProperty(copy.authenticatorSelection, 'require_resident_key', 'requireResidentKey');
+    }
+
+    this.logSuccess('گزینه‌های احراز هویت آماده شد', copy);
+    return copy as PublicKeyCredentialRequestOptions;
+  }
+
+  private bufferDecode(value: string): Uint8Array {
+    return Uint8Array.from(atob(value.replace(/_/g, '/').replace(/-/g, '+')), (c) => c.charCodeAt(0));
+  }
+
+  private bufferEncode(value: ArrayBuffer | ArrayBufferView): string {
+    const buffer = value instanceof ArrayBuffer ? new Uint8Array(value) : new Uint8Array(value.buffer);
+    let binary = '';
+    buffer.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  }
+
+  private toBufferSource(value: unknown): ArrayBuffer | ArrayBufferView | null {
+    if (!value) {
+      return null;
+    }
+
+    if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+      return value as ArrayBuffer | ArrayBufferView;
+    }
+
+    if (typeof value === 'string') {
+      return this.bufferDecode(value);
+    }
+
+    throw new TypeError('Unsupported credential buffer value');
+  }
 }


### PR DESCRIPTION
## Summary
- rebuild the temporary WebAuthn test client as a standalone Angular component with full WebAuthn flows
- replace the ad-hoc HTML/JS page with bound templates, reactive logging, and NG-ZORRO styled layout consistent with the dashboard
- add component-specific styling and unit test scaffolding that stubs fetch to keep initialization stable

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless --progress=false *(fails: repository has existing spec import/type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d44ff1bbc083299ff407d856435618